### PR TITLE
Include Boost libraries in the toolchain

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -g26c91a9790-dirty Configuration
+# Buildroot -g5ce34ced Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -1731,6 +1731,7 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 # libgit2 needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBODB is not set
+# BR2_PACKAGE_LIBODB_BOOST is not set
 # BR2_PACKAGE_MYSQL is not set
 
 #
@@ -2574,7 +2575,60 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 # belr needs a toolchain not affected by GCC bug 64735
 #
-# BR2_PACKAGE_BOOST is not set
+BR2_PACKAGE_BOOST=y
+BR2_PACKAGE_BOOST_LAYOUT_SYSTEM=y
+# BR2_PACKAGE_BOOST_LAYOUT_TAGGED is not set
+# BR2_PACKAGE_BOOST_LAYOUT_VERSIONED is not set
+BR2_PACKAGE_BOOST_LAYOUT="system"
+# BR2_PACKAGE_BOOST_ATOMIC is not set
+# BR2_PACKAGE_BOOST_CHRONO is not set
+# BR2_PACKAGE_BOOST_CONTAINER is not set
+BR2_PACKAGE_BOOST_CONTEXT_ARCH_SUPPORTS=y
+# BR2_PACKAGE_BOOST_CONTRACT is not set
+
+#
+# boost-coroutine needs a toolchain not affected by GCC bug 64735
+#
+# BR2_PACKAGE_BOOST_DATE_TIME is not set
+# BR2_PACKAGE_BOOST_EXCEPTION is not set
+
+#
+# boost-fiber needs a toolchain not affected by GCC bug 64735
+#
+# BR2_PACKAGE_BOOST_FILESYSTEM is not set
+# BR2_PACKAGE_BOOST_GRAPH is not set
+# BR2_PACKAGE_BOOST_GRAPH_PARALLEL is not set
+# BR2_PACKAGE_BOOST_IOSTREAMS is not set
+# BR2_PACKAGE_BOOST_LOCALE is not set
+
+#
+# boost-log needs a toolchain not affected by GCC bug 64735
+#
+# BR2_PACKAGE_BOOST_MATH is not set
+# BR2_PACKAGE_BOOST_MPI is not set
+# BR2_PACKAGE_BOOST_PROGRAM_OPTIONS is not set
+# BR2_PACKAGE_BOOST_RANDOM is not set
+# BR2_PACKAGE_BOOST_REGEX is not set
+# BR2_PACKAGE_BOOST_SERIALIZATION is not set
+
+#
+# boost-stacktrace needs a toolchain w/ dynamic library
+#
+# BR2_PACKAGE_BOOST_SYSTEM is not set
+# BR2_PACKAGE_BOOST_TEST is not set
+
+#
+# boost-thread needs a toolchain not affected by GCC bug 64735
+#
+# BR2_PACKAGE_BOOST_TIMER is not set
+
+#
+# boost-type_erasure needs a toolchain not affected by GCC bug 64735
+#
+
+#
+# boost-wave needs a toolchain not affected by GCC bug 64735
+#
 
 #
 # c-capnproto needs host and target gcc >= 5 w/ C++14, threads, atomic, ucontext and not gcc bug 64735


### PR DESCRIPTION
The older uClibc toolchain included Boost, and [GmenuNX depends on it](https://github.com/nfriedly/gmenunx/runs/5261856673?check_suite_focus=true#step:4:335). This updates the buildroot configuration to include it when building the musl toolchain also. 

Added via `make menuconfig`, using `/` to search for "boost", enabling just the top-level Boost package, but not any of it's sub-options, and saving.

We may end up needing one or more of those sub-options, as GmenuNX still fails to compile, but this time the [error](https://github.com/nfriedly/gmenunx/runs/5274905276?check_suite_focus=true#step:4:332) is:

```
src/selector.cpp:291:9: error: reference to 'unordered_map' is ambiguous
  291 |         unordered_map<string, string>::iterator i = aliases.find(key);
```

I'll see if I can figure that one out sometime soon, but I'm pretty confident that this is at least a step in the right direction towards being able to [compile GmenuNX and other software in Github Actions](https://github.com/MiyooCFW/gmenunx/pull/6). 

