### PR TITLE
External toolchain + CI build

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -g2541bc10-dirty Configuration
+# Buildroot -g94c0b515 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -203,10 +203,10 @@ BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 #
 # Security Hardening Options
 #
-
-#
-# Stack Smashing Protection needs a toolchain w/ SSP
-#
+BR2_SSP_NONE=y
+# BR2_SSP_REGULAR is not set
+# BR2_SSP_STRONG is not set
+# BR2_SSP_ALL is not set
 
 #
 # RELocation Read Only (RELRO) needs shared libraries
@@ -314,7 +314,8 @@ BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_14=y
 # (e)glibc only available with shared lib support
 #
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_MUSL=y
-# BR2_TOOLCHAIN_EXTERNAL_HAS_SSP is not set
+BR2_TOOLCHAIN_EXTERNAL_HAS_SSP=y
+BR2_TOOLCHAIN_EXTERNAL_HAS_SSP_STRONG=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
 # BR2_TOOLCHAIN_EXTERNAL_DLANG is not set
 # BR2_TOOLCHAIN_EXTERNAL_FORTRAN is not set
@@ -337,6 +338,8 @@ BR2_INSTALL_LIBSTDCPP=y
 BR2_TOOLCHAIN_HAS_THREADS=y
 BR2_TOOLCHAIN_HAS_THREADS_DEBUG=y
 BR2_TOOLCHAIN_HAS_THREADS_NPTL=y
+BR2_TOOLCHAIN_HAS_SSP=y
+BR2_TOOLCHAIN_HAS_SSP_STRONG=y
 BR2_TOOLCHAIN_HAS_UCONTEXT=y
 BR2_USE_MMU=y
 BR2_TARGET_OPTIMIZATION="-fno-PIC -march=armv5te -mtune=arm926ej-s"

--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -g5ce34ced Configuration
+# Buildroot -g2541bc10-dirty Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -183,7 +183,9 @@ BR2_STRIP_EXCLUDE_DIRS=""
 # BR2_OPTIMIZE_1 is not set
 # BR2_OPTIMIZE_2 is not set
 # BR2_OPTIMIZE_3 is not set
+# BR2_OPTIMIZE_G is not set
 BR2_OPTIMIZE_S=y
+# BR2_OPTIMIZE_FAST is not set
 BR2_STATIC_LIBS=y
 # BR2_SHARED_LIBS is not set
 # BR2_SHARED_STATIC_LIBS is not set
@@ -195,14 +197,16 @@ BR2_GLOBAL_PATCH_DIR=""
 #
 BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 # BR2_FORCE_HOST_BUILD is not set
+# BR2_REPRODUCIBLE is not set
 # BR2_PER_PACKAGE_DIRECTORIES is not set
 
 #
 # Security Hardening Options
 #
-BR2_SSP_NONE=y
-# BR2_SSP_REGULAR is not set
-# BR2_SSP_ALL is not set
+
+#
+# Stack Smashing Protection needs a toolchain w/ SSP
+#
 
 #
 # RELocation Read Only (RELRO) needs shared libraries
@@ -217,68 +221,105 @@ BR2_SSP_NONE=y
 #
 BR2_TOOLCHAIN=y
 BR2_TOOLCHAIN_USES_MUSL=y
-BR2_TOOLCHAIN_BUILDROOT=y
-# BR2_TOOLCHAIN_EXTERNAL is not set
+# BR2_TOOLCHAIN_BUILDROOT is not set
+BR2_TOOLCHAIN_EXTERNAL=y
 
 #
-# Toolchain Buildroot Options
+# Toolchain External Options
 #
-BR2_TOOLCHAIN_BUILDROOT_VENDOR="buildroot"
-# BR2_TOOLCHAIN_BUILDROOT_UCLIBC is not set
 
 #
-# glibc needs a toolchain w/ dynamic library, kernel headers >= 3.2
+# glibc toolchains only available with shared lib support
 #
-BR2_TOOLCHAIN_BUILDROOT_MUSL=y
-BR2_TOOLCHAIN_BUILDROOT_LIBC="musl"
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN is not set
+BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
+# BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD is not set
+BR2_TOOLCHAIN_EXTERNAL_PREINSTALLED=y
+BR2_TOOLCHAIN_EXTERNAL_PATH="/opt/miyoo"
+BR2_TOOLCHAIN_EXTERNAL_MUSL=y
+BR2_PACKAGE_HAS_TOOLCHAIN_EXTERNAL=y
+BR2_PACKAGE_PROVIDES_TOOLCHAIN_EXTERNAL="toolchain-external-custom"
+BR2_TOOLCHAIN_EXTERNAL_PREFIX="arm-buildroot-linux-musleabi"
+BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_ARCH_SUPPORTS=y
+BR2_TOOLCHAIN_EXTERNAL_CUSTOM_PREFIX="arm-buildroot-linux-musleabi"
+BR2_TOOLCHAIN_EXTERNAL_GCC_10=y
+# BR2_TOOLCHAIN_EXTERNAL_GCC_9 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_8 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_7 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_6 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_5 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_9 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_8 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_7 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_6 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_5 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_4 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_4_3 is not set
+# BR2_TOOLCHAIN_EXTERNAL_GCC_OLD is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_9 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_8 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_7 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_6 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_5 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_4 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_3 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_2 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_1 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_5_0 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_20 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_19 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_18 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_17 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_16 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_15 is not set
+BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_14=y
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_13 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_12 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_11 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_10 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_9 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_8 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_7 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_6 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_5 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_4 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_3 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_2 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_1 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_0 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_19 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_18 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_17 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_16 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_15 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_14 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_13 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_12 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_11 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_10 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_9 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_8 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_7 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_6 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_5 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_4 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_3 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_2 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_1 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_0 is not set
+# BR2_TOOLCHAIN_EXTERNAL_HEADERS_REALLY_OLD is not set
+# BR2_TOOLCHAIN_EXTERNAL_CUSTOM_UCLIBC is not set
 
 #
-# Kernel Header Options
+# (e)glibc only available with shared lib support
 #
-# BR2_KERNEL_HEADERS_4_4 is not set
-# BR2_KERNEL_HEADERS_4_9 is not set
-BR2_KERNEL_HEADERS_4_14=y
-# BR2_KERNEL_HEADERS_4_19 is not set
-# BR2_KERNEL_HEADERS_5_4 is not set
-# BR2_KERNEL_HEADERS_5_8 is not set
-# BR2_KERNEL_HEADERS_5_9 is not set
-# BR2_KERNEL_HEADERS_VERSION is not set
-# BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
-# BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_DEFAULT_KERNEL_HEADERS="4.14.200"
-BR2_PACKAGE_LINUX_HEADERS=y
-BR2_PACKAGE_MUSL=y
-
-#
-# Binutils Options
-#
-BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
-# BR2_BINUTILS_VERSION_2_32_X is not set
-# BR2_BINUTILS_VERSION_2_33_X is not set
-# BR2_BINUTILS_VERSION_2_34_X is not set
-BR2_BINUTILS_VERSION_2_35_X=y
-BR2_BINUTILS_VERSION="2.35.1"
-BR2_BINUTILS_ENABLE_LTO=y
-BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
-
-#
-# GCC Options
-#
-# BR2_GCC_VERSION_8_X is not set
-# BR2_GCC_VERSION_9_X is not set
-# BR2_GCC_VERSION_10_X is not set
-BR2_GCC_VERSION_11_X=y
-BR2_GCC_SUPPORTS_LIBCILKRTS=y
-BR2_GCC_VERSION="11.2.0"
-BR2_EXTRA_GCC_CONFIG_OPTIONS=""
-BR2_TOOLCHAIN_BUILDROOT_CXX=y
-# BR2_TOOLCHAIN_BUILDROOT_FORTRAN is not set
-BR2_GCC_ENABLE_LTO=y
-# BR2_GCC_ENABLE_OPENMP is not set
-
-#
-# graphite support needs gcc >= 5.x
-#
+BR2_TOOLCHAIN_EXTERNAL_CUSTOM_MUSL=y
+# BR2_TOOLCHAIN_EXTERNAL_HAS_SSP is not set
+BR2_TOOLCHAIN_EXTERNAL_CXX=y
+# BR2_TOOLCHAIN_EXTERNAL_DLANG is not set
+# BR2_TOOLCHAIN_EXTERNAL_FORTRAN is not set
+# BR2_TOOLCHAIN_EXTERNAL_OPENMP is not set
+# BR2_TOOLCHAIN_EXTERNAL_GDB_SERVER_COPY is not set
 BR2_PACKAGE_HOST_GDB_ARCH_SUPPORTS=y
 
 #
@@ -290,14 +331,12 @@ BR2_PACKAGE_HOST_GDB_ARCH_SUPPORTS=y
 # Toolchain Generic Options
 #
 BR2_TOOLCHAIN_SUPPORTS_VARIADIC_MI_THUNK=y
-BR2_TOOLCHAIN_HAS_GCC_BUG_64735=y
 BR2_USE_WCHAR=y
 BR2_ENABLE_LOCALE=y
 BR2_INSTALL_LIBSTDCPP=y
 BR2_TOOLCHAIN_HAS_THREADS=y
 BR2_TOOLCHAIN_HAS_THREADS_DEBUG=y
 BR2_TOOLCHAIN_HAS_THREADS_NPTL=y
-BR2_TOOLCHAIN_HAS_SSP=y
 BR2_TOOLCHAIN_HAS_UCONTEXT=y
 BR2_USE_MMU=y
 BR2_TARGET_OPTIMIZATION="-fno-PIC -march=armv5te -mtune=arm926ej-s"
@@ -339,9 +378,26 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_12=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_13=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_14=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST="4.14"
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_5=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_6=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_7=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_8=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_4_9=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_5=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_6=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_7=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_8=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_9=y
+BR2_TOOLCHAIN_GCC_AT_LEAST_10=y
+BR2_TOOLCHAIN_GCC_AT_LEAST="10"
+BR2_TOOLCHAIN_HAS_MNAN_OPTION=y
 BR2_TOOLCHAIN_HAS_SYNC_1=y
 BR2_TOOLCHAIN_HAS_SYNC_2=y
 BR2_TOOLCHAIN_HAS_SYNC_4=y
+BR2_TOOLCHAIN_HAS_LIBATOMIC=y
+BR2_TOOLCHAIN_HAS_ATOMIC=y
 
 #
 # System configuration
@@ -532,18 +588,13 @@ BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MJPEGTOOLS is not set
 # BR2_PACKAGE_MODPLUGTOOLS is not set
 # BR2_PACKAGE_MOTION is not set
-
-#
-# mpd needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_MPD is not set
 # BR2_PACKAGE_MPD_MPC is not set
 BR2_PACKAGE_MPG123=y
+# BR2_PACKAGE_MPV is not set
 # BR2_PACKAGE_MULTICAT is not set
 # BR2_PACKAGE_MUSEPACK is not set
-
-#
-# ncmpc needs a toolchain w/ C++, wchar, threads, gcc >= 7
-#
+# BR2_PACKAGE_NCMPC is not set
 
 #
 # omxplayer needs rpi-userland and a toolchain w/ C++, threads, wchar, dynamic library
@@ -569,10 +620,7 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 #
 # BR2_PACKAGE_TWOLAME is not set
 # BR2_PACKAGE_UDPXY is not set
-
-#
-# upmpdcli needs a toolchain w/ C++, NPTL, gcc >= 4.9
-#
+# BR2_PACKAGE_UPMPDCLI is not set
 
 #
 # v4l2grab needs a toolchain w/ threads, dynamic library, C++ and headers >= 3.0
@@ -645,10 +693,7 @@ BR2_PACKAGE_BZIP2=y
 # fio needs a toolchain w/ dynamic library, threads
 #
 BR2_PACKAGE_GDB_ARCH_SUPPORTS=y
-
-#
-# gdb/gdbserver >= 8.x needs a toolchain w/ C++, gcc >= 4.8
-#
+# BR2_PACKAGE_GDB is not set
 BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 
 #
@@ -743,14 +788,7 @@ BR2_PACKAGE_CMAKE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GETTEXT is not set
 BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_GIT is not set
-
-#
-# git-crypt needs a toolchain w/ C++, gcc >= 4.9
-#
-
-#
-# git-crypt needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_GIT_CRYPT is not set
 # BR2_PACKAGE_GPERF is not set
 # BR2_PACKAGE_JO is not set
 # BR2_PACKAGE_JQ is not set
@@ -890,7 +928,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_LTRIS is not set
 
 #
-# minetest needs a toolchain w/ C++, gcc >= 4.9, threads
+# minetest needs X11 and an OpenGL provider
 #
 # BR2_PACKAGE_OPENTYRIAN is not set
 # BR2_PACKAGE_PRBOOM is not set
@@ -902,10 +940,6 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 
 #
 # stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 6
-#
-
-#
-# stella needs a toolchain not affected by GCC bug 64735
 #
 
 #
@@ -934,7 +968,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_GHOSTSCRIPT is not set
 
 #
-# glmark2 needs a toolchain w/ C++, gcc >= 4.9
+# glmark2 needs an OpenGL or an openGL ES and EGL backend
 #
 
 #
@@ -1068,10 +1102,6 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# vte needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
-#
-
-#
 # vte needs an OpenGL or an OpenGL-EGL/wayland backend
 #
 # BR2_PACKAGE_XKEYBOARD_CONFIG is not set
@@ -1158,6 +1188,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # BR2_PACKAGE_DUMP1090 is not set
 # BR2_PACKAGE_DVB_APPS is not set
 # BR2_PACKAGE_DVBSNOOP is not set
+# BR2_PACKAGE_EDID_DECODE is not set
 
 #
 # edid-decode needs a toolchain w/ C++, gcc >= 4.7
@@ -1202,10 +1233,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_IPMITOOL is not set
 # BR2_PACKAGE_IRDA_UTILS is not set
-
-#
-# kbd needs a toolchain w/ gcc >= 4.9
-#
+# BR2_PACKAGE_KBD is not set
 
 #
 # lcdproc needs a toolchain w/  dynamic library
@@ -1319,10 +1347,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_SDPARM is not set
 BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
-
-#
-# sedutil needs a toolchain w/ C++, gcc >= 4.8, headers >= 3.12
-#
+# BR2_PACKAGE_SEDUTIL is not set
 # BR2_PACKAGE_SETSERIAL is not set
 # BR2_PACKAGE_SG3_UTILS is not set
 
@@ -1512,14 +1537,7 @@ BR2_PACKAGE_ALSA_LIB_SEQ=y
 BR2_PACKAGE_ALSA_LIB_UCM=y
 BR2_PACKAGE_ALSA_LIB_ALISP=y
 BR2_PACKAGE_ALSA_LIB_OLD_SYMBOLS=y
-
-#
-# alure needs a toolchain w/ C++, gcc >= 4.9, NPTL, wchar
-#
-
-#
-# alure needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_ALURE is not set
 
 #
 # aubio needs a toolchain w/ threads, dynamic library
@@ -1569,7 +1587,7 @@ BR2_PACKAGE_LIBSNDFILE=y
 BR2_PACKAGE_LIBVORBIS=y
 # BR2_PACKAGE_MP4V2 is not set
 BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
-BR2_PACKAGE_OPENAL=y
+# BR2_PACKAGE_OPENAL is not set
 # BR2_PACKAGE_OPENCORE_AMR is not set
 # BR2_PACKAGE_OPUS is not set
 # BR2_PACKAGE_OPUSFILE is not set
@@ -1589,10 +1607,7 @@ BR2_PACKAGE_PORTAUDIO_ALSA=y
 BR2_PACKAGE_TREMOR=y
 # BR2_PACKAGE_VO_AACENC is not set
 BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
-
-#
-# webrtc-audio-processing needs a toolchain w/ C++, NPTL, gcc >= 4.8
-#
+# BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING is not set
 
 #
 # Compression and decompression
@@ -1624,14 +1639,7 @@ BR2_PACKAGE_PROVIDES_HOST_ZLIB="host-libzlib"
 # BR2_PACKAGE_BEARSSL is not set
 # BR2_PACKAGE_BEECRYPT is not set
 BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
-
-#
-# botan needs a toolchain w/ C++, threads, gcc >= 4.8
-#
-
-#
-# botan needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_BOTAN is not set
 # BR2_PACKAGE_CA_CERTIFICATES is not set
 
 #
@@ -1663,10 +1671,7 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="arm-unknown-linux-gnueabi"
 #
 # libnss needs a toolchain w/ threads, dynamic library
 #
-
-#
-# libolm needs a toolchain w/ C++, gcc >= 4.8
-#
+# BR2_PACKAGE_LIBOLM is not set
 
 #
 # libp11 needs a toolchain w/ dynamic library
@@ -1722,16 +1727,12 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 #
 # kompexsqlite needs a toolchain w/ C++, wchar, threads, dynamic library
 #
-
-#
-# leveldb needs a toolchain w/ C++, threads, gcc >= 4.8
-#
+# BR2_PACKAGE_LEVELDB is not set
 
 #
 # libgit2 needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBODB is not set
-# BR2_PACKAGE_LIBODB_BOOST is not set
 # BR2_PACKAGE_MYSQL is not set
 
 #
@@ -1739,12 +1740,9 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 #
 
 #
-# rocksdb needs a toolchain w/ C++, threads, wchar, gcc >= 4.8
+# redis needs a toolchain w/ gcc>=4.9, dynamic library, nptl
 #
-
-#
-# rocksdb needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_ROCKSDB is not set
 # BR2_PACKAGE_SQLCIPHER is not set
 # BR2_PACKAGE_SQLITE is not set
 
@@ -1785,17 +1783,11 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 # at-spi2-core depends on X.org
 #
 # BR2_PACKAGE_ATK is not set
-BR2_PACKAGE_AGG=y
-
-#
-# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_AGG is not set
+# BR2_PACKAGE_ATKMM is not set
 # BR2_PACKAGE_BULLET is not set
 # BR2_PACKAGE_CAIRO is not set
-
-#
-# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.8
-#
+# BR2_PACKAGE_CAIROMM is not set
 
 #
 # chipmunk needs an OpenGL backend
@@ -1826,10 +1818,7 @@ BR2_PACKAGE_FREETYPE=y
 #
 # gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
 #
-
-#
-# harfbuzz needs a toolchain w/ C++, gcc => 4.8
-#
+# BR2_PACKAGE_HARFBUZZ is not set
 # BR2_PACKAGE_IJS is not set
 
 #
@@ -1850,10 +1839,7 @@ BR2_PACKAGE_LIBJPEG=y
 # BR2_PACKAGE_JPEG_TURBO is not set
 BR2_PACKAGE_HAS_JPEG=y
 BR2_PACKAGE_PROVIDES_JPEG="libjpeg"
-
-#
-# kms++ needs a toolchain w/ threads, C++, gcc >= 4.8, headers >= 3.8
-#
+# BR2_PACKAGE_KMSXX is not set
 # BR2_PACKAGE_LCMS2 is not set
 # BR2_PACKAGE_LENSFUN is not set
 # BR2_PACKAGE_LEPTONICA is not set
@@ -1878,10 +1864,7 @@ BR2_PACKAGE_PROVIDES_JPEG="libjpeg"
 #
 # libfreeimage needs a toolchain w/ C++, dynamic library, wchar
 #
-
-#
-# libgeotiff needs a toolchain w/ C++, gcc >= 4.7, threads, wchar
-#
+# BR2_PACKAGE_LIBGEOTIFF is not set
 
 #
 # libglew depends on X.org and needs an OpenGL backend
@@ -1895,10 +1878,6 @@ BR2_PACKAGE_PROVIDES_JPEG="libjpeg"
 # libglu needs an OpenGL backend
 #
 # BR2_PACKAGE_LIBGTA is not set
-
-#
-# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
-#
 
 #
 # libgtk3 needs an OpenGL or an OpenGL-EGL/wayland backend
@@ -1926,15 +1905,13 @@ BR2_PACKAGE_LIBPNG=y
 #
 # BR2_PACKAGE_MENU_CACHE is not set
 # BR2_PACKAGE_OPENCV is not set
+
+#
+# opencv3 needs a toolchain w/ C++, NPTL, wchar, dynamic library
+#
 # BR2_PACKAGE_OPENJPEG is not set
-
-#
-# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
-#
-
-#
-# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_PANGO is not set
+# BR2_PACKAGE_PANGOMM is not set
 
 #
 # pipewire needs udev and a toolchain w/ threads
@@ -2056,10 +2033,7 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBQMI is not set
 # BR2_PACKAGE_LIBRAW1394 is not set
 # BR2_PACKAGE_LIBRTLSDR is not set
-
-#
-# libserial needs a toolchain w/ C++, gcc >= 5, threads, wchar
-#
+# BR2_PACKAGE_LIBSERIAL is not set
 # BR2_PACKAGE_LIBSERIALPORT is not set
 
 #
@@ -2094,10 +2068,6 @@ BR2_PACKAGE_MRAA_ARCH_SUPPORTS=y
 
 #
 # uhd needs a toolchain w/ C++, NPTL, wchar, dynamic library
-#
-
-#
-# uhd needs a toolchain not affected by GCC bug 64735
 #
 # BR2_PACKAGE_URG is not set
 
@@ -2135,25 +2105,16 @@ BR2_PACKAGE_EXPAT=y
 # BR2_PACKAGE_JOSE is not set
 # BR2_PACKAGE_JSMN is not set
 # BR2_PACKAGE_JSON_C is not set
-
-#
-# json-for-modern-cpp needs a toolchain w/ C++, gcc >= 4.9
-#
+# BR2_PACKAGE_JSON_FOR_MODERN_CPP is not set
 # BR2_PACKAGE_JSON_GLIB is not set
-
-#
-# jsoncpp needs a toolchain w/ C++, gcc >= 4.7
-#
+# BR2_PACKAGE_JSONCPP is not set
 # BR2_PACKAGE_LIBBSON is not set
 # BR2_PACKAGE_LIBFASTJSON is not set
 # BR2_PACKAGE_LIBJSON is not set
 # BR2_PACKAGE_LIBROXML is not set
 # BR2_PACKAGE_LIBUCL is not set
 # BR2_PACKAGE_LIBXML2 is not set
-
-#
-# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_LIBXMLPP is not set
 # BR2_PACKAGE_LIBXMLRPC is not set
 # BR2_PACKAGE_LIBXSLT is not set
 # BR2_PACKAGE_LIBYAML is not set
@@ -2167,10 +2128,7 @@ BR2_PACKAGE_EXPAT=y
 # BR2_PACKAGE_VALIJSON is not set
 # BR2_PACKAGE_XERCES is not set
 # BR2_PACKAGE_YAJL is not set
-
-#
-# yaml-cpp needs a toolchain w/ C++, gcc >= 4.7
-#
+# BR2_PACKAGE_YAML_CPP is not set
 
 #
 # Logging
@@ -2178,14 +2136,7 @@ BR2_PACKAGE_EXPAT=y
 # BR2_PACKAGE_GLOG is not set
 # BR2_PACKAGE_LIBLOG4C_LOCALTIME is not set
 # BR2_PACKAGE_LIBLOGGING is not set
-
-#
-# log4cplus needs a toolchain w/ C++, wchar, threads, gcc >= 4.8
-#
-
-#
-# log4cplus needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_LOG4CPLUS is not set
 # BR2_PACKAGE_LOG4CPP is not set
 
 #
@@ -2194,10 +2145,6 @@ BR2_PACKAGE_EXPAT=y
 
 #
 # opentracing-cpp needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
-#
-
-#
-# opentracing-cpp needs exception_ptr
 #
 # BR2_PACKAGE_SPDLOG is not set
 
@@ -2265,10 +2212,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # mediastreamer needs a toolchain w/ threads, C++, dynamic library
 #
-
-#
-# mediastreamer needs a toolchain not affected by GCC bug 64735
-#
 # BR2_PACKAGE_X264 is not set
 
 #
@@ -2282,14 +2225,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 # agent++ needs a toolchain w/ threads, C++, dynamic library
 #
-
-#
-# azmq needs a toolchain w/ C++11, wchar and NPTL
-#
-
-#
-# azmq needs exception_ptr
-#
+# BR2_PACKAGE_AZMQ is not set
 # BR2_PACKAGE_AZURE_IOT_SDK_C is not set
 
 #
@@ -2298,10 +2234,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 
 #
 # belle-sip needs a toolchain w/ threads, C++, dynamic library, wchar
-#
-
-#
-# belle-sip needs a toolchain not affected by GCC bug 64735
 #
 # BR2_PACKAGE_C_ARES is not set
 BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
@@ -2319,6 +2251,10 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 
 #
 # daq needs a toolchain w/ dynamic library
+#
+
+#
+# davici needs a toolchain w/ threads, dynamic library
 #
 # BR2_PACKAGE_ENET is not set
 # BR2_PACKAGE_FILEMQ is not set
@@ -2343,10 +2279,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCGI is not set
 # BR2_PACKAGE_LIBCGICC is not set
 # BR2_PACKAGE_LIBCOAP is not set
-
-#
-# libcpprestsdk needs exception_ptr
-#
+# BR2_PACKAGE_LIBCPPRESTSDK is not set
 # BR2_PACKAGE_LIBCURL is not set
 # BR2_PACKAGE_LIBDNET is not set
 # BR2_PACKAGE_LIBEXOSIP2 is not set
@@ -2357,10 +2290,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 # libhttpparser needs a toolchain w/ dynamic library
 #
-
-#
-# libhttpserver needs a toolchain w/ C++, threads, gcc >= 5
-#
+# BR2_PACKAGE_LIBHTTPSERVER is not set
 # BR2_PACKAGE_LIBIDN is not set
 # BR2_PACKAGE_LIBIDN2 is not set
 # BR2_PACKAGE_LIBISCSI is not set
@@ -2407,10 +2337,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBNIDS is not set
 # BR2_PACKAGE_LIBNL is not set
-
-#
-# libnpupnp needs a toolchain w/ C++, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_LIBNPUPNP is not set
 # BR2_PACKAGE_LIBOAUTH is not set
 # BR2_PACKAGE_LIBOPING is not set
 # BR2_PACKAGE_LIBOSIP2 is not set
@@ -2431,18 +2358,12 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBTELNET is not set
 # BR2_PACKAGE_LIBTIRPC is not set
 # BR2_PACKAGE_LIBTORRENT is not set
-
-#
-# libtorrent-rasterbar needs exception_ptr
-#
+# BR2_PACKAGE_LIBTORRENT_RASTERBAR is not set
 # BR2_PACKAGE_LIBUEV is not set
 # BR2_PACKAGE_LIBUHTTPD is not set
 # BR2_PACKAGE_LIBUPNP is not set
 # BR2_PACKAGE_LIBUPNP18 is not set
-
-#
-# libupnpp needs a toolchain w/ C++, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_LIBUPNPP is not set
 # BR2_PACKAGE_LIBURIPARSER is not set
 # BR2_PACKAGE_LIBUWSC is not set
 
@@ -2494,19 +2415,10 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 # openzwave needs a toolchain w/ C++, dynamic library, NPTL, wchar
 #
-
-#
-# ortp needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_ORTP is not set
 # BR2_PACKAGE_PAHO_MQTT_C is not set
-
-#
-# paho-mqtt-cpp needs a toolchain not affected by GCC bug 64735
-#
-
-#
-# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar
-#
+# BR2_PACKAGE_PAHO_MQTT_CPP is not set
+# BR2_PACKAGE_PISTACHE is not set
 
 #
 # qpid-proton needs a toolchain w/ dynamic library
@@ -2516,10 +2428,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # rabbitmq-c needs a toolchain w/ dynamic library, threads
 #
 # BR2_PACKAGE_RESIPROCATE is not set
-
-#
-# restclient-cpp needs a toolchain w/ C++, gcc >= 4.8
-#
+# BR2_PACKAGE_RESTCLIENT_CPP is not set
 # BR2_PACKAGE_RTMPDUMP is not set
 # BR2_PACKAGE_SLIRP is not set
 
@@ -2535,17 +2444,11 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_USBREDIR is not set
 
 #
-# websocketpp needs a toolchain w/ C++ and gcc >= 4.8
+# wampcc needs a toolchain w/ C++, NPTL, dynamic library
 #
+# BR2_PACKAGE_WEBSOCKETPP is not set
 # BR2_PACKAGE_ZEROMQ is not set
-
-#
-# zmqpp needs a toolchain w/ C++, threads, gcc >= 4.7
-#
-
-#
-# zmqpp needs exception_ptr
-#
+# BR2_PACKAGE_ZMQPP is not set
 # BR2_PACKAGE_ZYRE is not set
 
 #
@@ -2566,92 +2469,17 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 # avro-c needs a toolchain w/ dynamic library
 #
-
-#
-# bctoolbox needs a toolchain not affected by GCC bug 64735
-#
+# BR2_PACKAGE_BCTOOLBOX is not set
 # BR2_PACKAGE_BDWGC is not set
-
-#
-# belr needs a toolchain not affected by GCC bug 64735
-#
-BR2_PACKAGE_BOOST=y
-BR2_PACKAGE_BOOST_LAYOUT_SYSTEM=y
-# BR2_PACKAGE_BOOST_LAYOUT_TAGGED is not set
-# BR2_PACKAGE_BOOST_LAYOUT_VERSIONED is not set
-BR2_PACKAGE_BOOST_LAYOUT="system"
-# BR2_PACKAGE_BOOST_ATOMIC is not set
-# BR2_PACKAGE_BOOST_CHRONO is not set
-# BR2_PACKAGE_BOOST_CONTAINER is not set
-BR2_PACKAGE_BOOST_CONTEXT_ARCH_SUPPORTS=y
-# BR2_PACKAGE_BOOST_CONTRACT is not set
-
-#
-# boost-coroutine needs a toolchain not affected by GCC bug 64735
-#
-# BR2_PACKAGE_BOOST_DATE_TIME is not set
-# BR2_PACKAGE_BOOST_EXCEPTION is not set
-
-#
-# boost-fiber needs a toolchain not affected by GCC bug 64735
-#
-# BR2_PACKAGE_BOOST_FILESYSTEM is not set
-# BR2_PACKAGE_BOOST_GRAPH is not set
-# BR2_PACKAGE_BOOST_GRAPH_PARALLEL is not set
-# BR2_PACKAGE_BOOST_IOSTREAMS is not set
-# BR2_PACKAGE_BOOST_LOCALE is not set
-
-#
-# boost-log needs a toolchain not affected by GCC bug 64735
-#
-# BR2_PACKAGE_BOOST_MATH is not set
-# BR2_PACKAGE_BOOST_MPI is not set
-# BR2_PACKAGE_BOOST_PROGRAM_OPTIONS is not set
-# BR2_PACKAGE_BOOST_RANDOM is not set
-# BR2_PACKAGE_BOOST_REGEX is not set
-# BR2_PACKAGE_BOOST_SERIALIZATION is not set
-
-#
-# boost-stacktrace needs a toolchain w/ dynamic library
-#
-# BR2_PACKAGE_BOOST_SYSTEM is not set
-# BR2_PACKAGE_BOOST_TEST is not set
-
-#
-# boost-thread needs a toolchain not affected by GCC bug 64735
-#
-# BR2_PACKAGE_BOOST_TIMER is not set
-
-#
-# boost-type_erasure needs a toolchain not affected by GCC bug 64735
-#
-
-#
-# boost-wave needs a toolchain not affected by GCC bug 64735
-#
-
-#
-# c-capnproto needs host and target gcc >= 5 w/ C++14, threads, atomic, ucontext and not gcc bug 64735
-#
-
-#
-# capnproto needs host and target gcc >= 5 w/ C++14, threads, atomic, ucontext and not gcc bug 64735
-#
-
-#
-# cctz needs a toolchain w/ C++, threads, gcc >= 4.8
-#
-
-#
-# cereal needs a toolchain w/ C++, gcc >= 4.7, threads, wchar
-#
+# BR2_PACKAGE_BELR is not set
+# BR2_PACKAGE_BOOST is not set
+# BR2_PACKAGE_C_CAPNPROTO is not set
+# BR2_PACKAGE_CAPNPROTO is not set
+# BR2_PACKAGE_CCTZ is not set
+# BR2_PACKAGE_CEREAL is not set
 
 #
 # clang needs a toolchain w/ wchar, threads, C++, gcc >= 4.8, dynamic library
-#
-
-#
-# clang needs a toolchain not affected by GCC bug 64735
 #
 # BR2_PACKAGE_CLAPACK is not set
 
@@ -2663,10 +2491,7 @@ BR2_PACKAGE_BOOST_CONTEXT_ARCH_SUPPORTS=y
 # cppcms needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
 # BR2_PACKAGE_CRACKLIB is not set
-
-#
-# dawgdic needs a toolchain w/ C++, gcc >= 4.6
-#
+# BR2_PACKAGE_DAWGDIC is not set
 # BR2_PACKAGE_DING_LIBS is not set
 # BR2_PACKAGE_EIGEN is not set
 
@@ -2682,10 +2507,7 @@ BR2_PACKAGE_BOOST_CONTEXT_ARCH_SUPPORTS=y
 #
 # flann needs a toolchain w/ C++, dynamic library
 #
-
-#
-# flatbuffers needs a toolchain w/ C++, gcc >= 4.7
-#
+# BR2_PACKAGE_FLATBUFFERS is not set
 # BR2_PACKAGE_FLATCC is not set
 
 #
@@ -2693,10 +2515,7 @@ BR2_PACKAGE_BOOST_CONTEXT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_GFLAGS is not set
 # BR2_PACKAGE_GLI is not set
-
-#
-# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
-#
+# BR2_PACKAGE_GLIBMM is not set
 # BR2_PACKAGE_GLM is not set
 # BR2_PACKAGE_GMP is not set
 BR2_PACKAGE_GOBJECT_INTROSPECTION_ARCH_SUPPORTS=y
@@ -2749,10 +2568,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 # libcorrect needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBCROCO is not set
-
-#
-# libcrossguid needs a toolchain w/ C++, gcc >= 4.7
-#
+# BR2_PACKAGE_LIBCROSSGUID is not set
 # BR2_PACKAGE_LIBCSV is not set
 # BR2_PACKAGE_LIBDAEMON is not set
 # BR2_PACKAGE_LIBEE is not set
@@ -2783,16 +2599,10 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBPWQUALITY is not set
 BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSECCOMP is not set
-
-#
-# libsigc++ needs a toolchain w/ C++, gcc >= 4.8
-#
+# BR2_PACKAGE_LIBSIGC is not set
 BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSIGSEGV is not set
-
-#
-# libspatialindex needs a toolchain w/ C++, gcc >= 4.7
-#
+# BR2_PACKAGE_LIBSPATIALINDEX is not set
 # BR2_PACKAGE_LIBTASN1 is not set
 # BR2_PACKAGE_LIBTOMMATH is not set
 # BR2_PACKAGE_LIBTPL is not set
@@ -2832,10 +2642,6 @@ BR2_PACKAGE_LLVM_TARGET_ARCH="ARM"
 
 #
 # llvm needs a toolchain w/ wchar, threads, C++, gcc >= 4.8, dynamic library
-#
-
-#
-# llvm needs a toolchain not affected by GCC bug 64735
 #
 
 #
@@ -2907,12 +2713,9 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_AUGEAS is not set
 # BR2_PACKAGE_ENCHANT is not set
-BR2_PACKAGE_FMT=y
+# BR2_PACKAGE_FMT is not set
 # BR2_PACKAGE_FSTRCMP is not set
-
-#
-# icu needs a toolchain w/ C++, wchar, threads, gcc >= 4.9, host gcc >= 4.9
-#
+# BR2_PACKAGE_ICU is not set
 # BR2_PACKAGE_LIBCLI is not set
 # BR2_PACKAGE_LIBEDIT is not set
 # BR2_PACKAGE_LIBENCA is not set
@@ -2932,10 +2735,7 @@ BR2_PACKAGE_NCURSES_ADDITIONAL_TERMINFO=""
 # BR2_PACKAGE_PCRE is not set
 # BR2_PACKAGE_PCRE2 is not set
 # BR2_PACKAGE_POPT is not set
-
-#
-# re2 needs a toolchain w/ C++, threads, gcc >= 4.8
-#
+# BR2_PACKAGE_RE2 is not set
 # BR2_PACKAGE_READLINE is not set
 # BR2_PACKAGE_SLANG is not set
 # BR2_PACKAGE_TCLAP is not set
@@ -2966,6 +2766,8 @@ BR2_PACKAGE_NCURSES_ADDITIONAL_TERMINFO=""
 #
 # BR2_PACKAGE_AESPIPE is not set
 # BR2_PACKAGE_BC is not set
+BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
+# BR2_PACKAGE_BITCOIN is not set
 
 #
 # clamav needs a toolchain w/ C++, dynamic library, threads, wchar
@@ -2979,27 +2781,15 @@ BR2_PACKAGE_NCURSES_ADDITIONAL_TERMINFO=""
 #
 # domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 4.8, NPTL, wchar, dynamic library
 #
-
-#
-# domoticz needs exception_ptr
-#
 # BR2_PACKAGE_EMPTY is not set
 
 #
 # gnuradio needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
-
-#
-# gnuradio needs a toolchain not affected by GCC bug 64735
-#
 # BR2_PACKAGE_GOOGLEFONTDIRECTORY is not set
 
 #
 # gqrx needs qt5
-#
-
-#
-# gqrx needs a toolchain not affected by GCC bug 64735
 #
 # BR2_PACKAGE_GSETTINGS_DESKTOP_SCHEMAS is not set
 # BR2_PACKAGE_HAVEGED is not set
@@ -3010,16 +2800,10 @@ BR2_PACKAGE_NCURSES_ADDITIONAL_TERMINFO=""
 #
 # netdata needs a toolchain w/ NPTL, dynamic library
 #
-
-#
-# proj needs a toolchain w/ C++, gcc >= 4.7, threads, wchar
-#
+# BR2_PACKAGE_PROJ is not set
 BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # BR2_PACKAGE_QEMU is not set
-
-#
-# qpdf needs a toolchain w/ C++, wchar, gcc >= 4.7
-#
+# BR2_PACKAGE_QPDF is not set
 # BR2_PACKAGE_SHARED_MIME_INFO is not set
 # BR2_PACKAGE_SUNWAIT is not set
 
@@ -3138,6 +2922,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # frr needs a toolchain w/ threads, dynamic library
 #
+# BR2_PACKAGE_GERBERA is not set
 # BR2_PACKAGE_GESFTPSERVER is not set
 # BR2_PACKAGE_GLOOX is not set
 # BR2_PACKAGE_GLORYTUN is not set
@@ -3155,6 +2940,7 @@ BR2_PACKAGE_HAPROXY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOSTAPD is not set
 # BR2_PACKAGE_HTPDATE is not set
 # BR2_PACKAGE_HTTPING is not set
+# BR2_PACKAGE_I2PD is not set
 # BR2_PACKAGE_IBRDTN_TOOLS is not set
 # BR2_PACKAGE_IBRDTND is not set
 # BR2_PACKAGE_IFMETRIC is not set
@@ -3210,10 +2996,6 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 #
 # linphone needs a toolchain w/ threads, C++, dynamic library, wchar
 #
-
-#
-# linphone needs a toolchain not affected by GCC bug 64735
-#
 # BR2_PACKAGE_LINUX_ZIGBEE is not set
 # BR2_PACKAGE_LINUXPTP is not set
 # BR2_PACKAGE_LLDPD is not set
@@ -3257,10 +3039,7 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # BR2_PACKAGE_MTR is not set
 # BR2_PACKAGE_NBD is not set
 # BR2_PACKAGE_NCFTP is not set
-
-#
-# ndisc6 needs a toolchain w/ gcc >= 4.7
-#
+# BR2_PACKAGE_NDISC6 is not set
 
 #
 # netatalk needs a toolchain w/ threads, dynamic library
@@ -3350,10 +3129,7 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # BR2_PACKAGE_RPCBIND is not set
 # BR2_PACKAGE_RSH_REDONE is not set
 # BR2_PACKAGE_RSYNC is not set
-
-#
-# rtorrent needs a toolchain w/ C++, threads, wchar, gcc >= 4.9
-#
+# BR2_PACKAGE_RTORRENT is not set
 # BR2_PACKAGE_RTPTOOLS is not set
 # BR2_PACKAGE_RYGEL is not set
 # BR2_PACKAGE_S6_DNS is not set
@@ -3384,9 +3160,14 @@ BR2_PACKAGE_IFUPDOWN_SCRIPTS=y
 # BR2_PACKAGE_SOFTETHER is not set
 # BR2_PACKAGE_SPAWN_FCGI is not set
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
+# BR2_PACKAGE_SQUID is not set
 # BR2_PACKAGE_SSHGUARD is not set
 # BR2_PACKAGE_SSHPASS is not set
 # BR2_PACKAGE_SSLH is not set
+
+#
+# strongswan needs a toolchain w/ threads, dynamic library
+#
 # BR2_PACKAGE_STUNNEL is not set
 # BR2_PACKAGE_SURICATA is not set
 # BR2_PACKAGE_TCPDUMP is not set
@@ -3772,10 +3553,7 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 # BR2_PACKAGE_WATCHDOG is not set
 # BR2_PACKAGE_XDG_DBUS_PROXY is not set
 BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
-
-#
-# xvisor needs a toolchain w/ gcc >= 4.9
-#
+# BR2_PACKAGE_XVISOR is not set
 
 #
 # Text editors and viewers

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -9,6 +9,7 @@ jobs:
       image: nfriedly/buildroot-toolchain:master
     env:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      FORCE_UNSAFE_CONFIGURE: 1
     steps:
     - uses: actions/checkout@v2
     - run: pwd

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: nfriedly/buildroot-toolchain:master
+    env:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
     - uses: actions/checkout@v2
     - run: pwd
@@ -16,8 +18,7 @@ jobs:
         #wget https://github.com/nfriedly/buildroot-toolchain/suites/5893824693/artifacts/200185195
         #tar -xvf arm-buildroot-linux-musleabi_sdk-buildroot.tar.gz
         #sudo mv arm-buildroot-linux-musleabi_sdk-buildroot /opt/miyoo
-        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/miyoo/bin:/opt/miyoo/arm-buildroot-linux-musleabi/sysroot/usr/bin
-make
+        make
     - uses: actions/upload-artifact@v2
       with:
         name: rootfs.tar

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -1,0 +1,25 @@
+name: Build Root Filesystem
+
+on: [push, pull_request]
+
+jobs:   
+  rootfs:
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/buildroot-toolchain:master
+    steps:
+    - uses: actions/checkout@v2
+    - run: pwd
+    - run: echo $PATH
+    - name: build
+      run: |
+        #wget https://github.com/nfriedly/buildroot-toolchain/suites/5893824693/artifacts/200185195
+        #tar -xvf arm-buildroot-linux-musleabi_sdk-buildroot.tar.gz
+        #sudo mv arm-buildroot-linux-musleabi_sdk-buildroot /opt/miyoo
+        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/miyoo/bin:/opt/miyoo/arm-buildroot-linux-musleabi/sysroot/usr/bin
+make
+    - uses: actions/upload-artifact@v2
+      with:
+        name: rootfs.tar
+        path: output/images/rootfs.tar
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`


### PR DESCRIPTION
This switches buildroot to use an external toolchain installed to `/opt/miyoo`, and only build the root fs from this repo. 

This pairs with https://github.com/MiyooCFW/toolchain / https://github.com/nfriedly/toolchain/, which I used to build the toolchain and publish a docker image. (I'll probably change the location of the docker image from my account to a miyoocfw one, but this works for the moment.)

This version of buildroot can use gcc 11 with an internal toolchain and had been configured to, but it's only capable of gcc 10 and older with an external toolchain, so I downgraded both sides to gcc 10 for now. This is another thing I plan to work on in the future; hopefully upgrading buildroot to the latest release will be sufficient.

The primary benefit here, beyond the separation of concerns, is speed: this change dramatically reduces the time this repo takes to build and, by extension, the main repo.

One thing worth mentioning: buildroot has an option to specify a url rather than a local folder for the toolchain. I didn't do that mainly because I think the folder variant will be faster when combined with a likely-to-be-cached docker image. Also, for whatever reason, github actions artifacts 404 when another action tries to download it.