### PR TITLE
add "showkey" to BusyBox default config

### DIFF
--- a/package/busybox/busybox.config
+++ b/package/busybox/busybox.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.35.0
-# Thu Jan 27 10:16:54 2022
+# Sun Mar 26 00:08:02 2023
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -385,7 +385,7 @@ CONFIG_SETCONSOLE=y
 # CONFIG_FEATURE_SETCONSOLE_LONG_OPTIONS is not set
 CONFIG_SETKEYCODES=y
 CONFIG_SETLOGCONS=y
-# CONFIG_SHOWKEY is not set
+CONFIG_SHOWKEY=y
 
 #
 # Debian Utilities
@@ -520,7 +520,7 @@ CONFIG_FEATURE_SHADOWPASSWDS=y
 # CONFIG_USE_BB_PWD_GRP is not set
 # CONFIG_USE_BB_SHADOW is not set
 CONFIG_USE_BB_CRYPT=y
-# CONFIG_USE_BB_CRYPT_SHA is not set
+CONFIG_USE_BB_CRYPT_SHA=y
 # CONFIG_ADD_SHELL is not set
 # CONFIG_REMOVE_SHELL is not set
 CONFIG_ADDGROUP=y


### PR DESCRIPTION
test keypad configuration from KDGKBMODE while executing ``showkey`` command in TTY.

current keycodes in:
https://github.com/MiyooCFW/kernel/blob/master/drivers/tty/vt/defkeymap.map

Usefull for device inputs debugging and with ``-s`` option you get raw codes.