### PR TITLE
Enable ccache

### DIFF
--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -33,6 +33,14 @@ jobs:
         path: ${{ inputs.submodule || '.' }}/output/images/miyoo-cfw-*.img
         key: ${{ steps.cache-key.outputs.key }}
       id: cache
+
+    - name: retrieve ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.buildroot-ccache
+        key: ${{ inputs.submodule }}-uclibc-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.submodule }}-uclibc-ccache-
         
     - name: build
       #if: steps.cache.outputs.cache-hit != 'true'
@@ -77,7 +85,15 @@ jobs:
         path: ${{ inputs.submodule || '.' }}/output/images/miyoo-cfw-*.img
         key: ${{ steps.cache-key.outputs.key }}
       id: cache
-        
+
+    - name: retrieve ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.buildroot-ccache
+        key: ${{ inputs.submodule }}-musl-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.submodule }}-musl-ccache-
+
     - name: build
       #if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/configs/miyoo_musl_defconfig
+++ b/configs/miyoo_musl_defconfig
@@ -3,6 +3,7 @@ BR2_SVN="svn"
 BR2_HOST_DIR="/opt/miyoo"
 BR2_CPAN_MIRROR="http://cpan.metacpan.org"
 BR2_JLEVEL=32
+BR2_CCACHE=y
 # BR2_PIC_PIE is not set
 BR2_SSP_NONE=y
 BR2_RELRO_NONE=y

--- a/configs/miyoo_uclibc_defconfig
+++ b/configs/miyoo_uclibc_defconfig
@@ -2,6 +2,7 @@ BR2_arm=y
 BR2_SVN="svn"
 BR2_HOST_DIR="/opt/miyoo"
 BR2_CPAN_MIRROR="http://cpan.metacpan.org"
+BR2_CCACHE=y
 BR2_RELRO_NONE=y
 BR2_TOOLCHAIN_BUILDROOT_VENDOR="miyoo"
 BR2_KERNEL_HEADERS_4_9=y


### PR DESCRIPTION
enabled BR2_CCACHE=y for all buildroot configs and added
actions/cache to the ci workflow to test if we can speed up build times.