### PR TITLE
[BOARD] add modules.custom.sh

### DIFF
--- a/board/miyoo/boot/modules.custom.sh
+++ b/board/miyoo/boot/modules.custom.sh
@@ -1,0 +1,9 @@
+# Leave one line uncommented to load expected video driver
+#
+modprobe r61520fb flip=1
+#modprobe r61520fb debug=1
+#modprobe st7789sfb lowcurrent=1 tefix=0
+#modprobe st7789sTEfb
+#modprobe rm68090fb
+#modprobe gc9306fb
+#modprobe hx8347dfb

--- a/board/miyoo/genimage-sdcard.cfg
+++ b/board/miyoo/genimage-sdcard.cfg
@@ -10,6 +10,7 @@ image bootfs.vfat {
 			"boot/console.cfg",
 			"boot/firstboot",
 			"boot/firstboot.custom.sh-OFF",
+			"boot/modules.custom.sh",
 			"boot/normalboot.custom.sh"
 		}
 		file configs/manifest {

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -70,9 +70,7 @@ gadget-ms /dev/mmcblk0p1 /dev/mmcblk0p4 >> "${LOGS}" 2>&1
 	  mv ${HOME}/.backlight.bak ${HOME}/.backlight.conf
 	  fi 
 	  # MODULES_CUSTOM scripting
-      if ((test -r "${BOOTDIR}/modules.custom.sh") && !(grep -q MODULES_CUSTOM\=\0 "${HOME}/options.cfg")); then
-          (cd "${BOOTDIR}" && sh modules.custom.sh ) >> "${LOGS}" 2>&1
-      else
+      if (!(test -r "${BOOTDIR}/modules.custom.sh") || !(grep -q MODULES_CUSTOM\=\1 "${HOME}/options.cfg")); then
 		# Load video module read from uEnv.txt & defined by variant in console.cfg
 		if (grep -q FLIP\=\1 "${HOME}/options.cfg"); then
 		modprobe $video $params flip=1
@@ -81,6 +79,8 @@ gadget-ms /dev/mmcblk0p1 /dev/mmcblk0p4 >> "${LOGS}" 2>&1
 		else
 		modprobe $video $params
 		fi
+      else
+        (cd "${BOOTDIR}" && sh modules.custom.sh ) >> "${LOGS}" 2>&1
       fi
     fi
 


### PR DESCRIPTION
Changed to disable by default but can be enabled from ``/mnt/options.cfg`` by adding ``MODULES_CUSTOM=1`` line