### PR TITLE
[PACKAGE] patch `fbgrab` compression arg

### DIFF
--- a/package/fbgrab/fbgrab-1.5.patch
+++ b/package/fbgrab/fbgrab-1.5.patch
@@ -1,0 +1,13 @@
+diff --git a/fbgrab.c b/fbgrab.c
+index 2abc08a..287cede 100644
+--- a/fbgrab.c
++++ b/fbgrab.c
+@@ -335,7 +335,7 @@ static void write_PNG(unsigned char *outbuffer, char *filename,
+ 
+     png_init_io(png_ptr, outfile);
+ 
+-    png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);
++    png_set_compression_level(png_ptr, compression);
+ 
+     bit_depth = 8;
+     color_type = PNG_COLOR_TYPE_RGB_ALPHA;


### PR DESCRIPTION
turns out `png_set_compression_level` was always defaulting to the best (9) even after providing `-z 0` arg - let`s fix that and make screenshots much faster

for reference: https://github.com/GunnarMonell/fbgrab/commit/230415e97590feeeae37579a6f429bfe1aa983ae