### PR TITLE
Maximize build space for `build-image-uclibc` and `build-image-musl`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       FORCE_UNSAFE_CONFIGURE: 1
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
+      uses: easimon/maximize-build-space@v8
       with:
         overprovision-lvm: true
         remove-dotnet: true
@@ -86,7 +86,7 @@ jobs:
       FORCE_UNSAFE_CONFIGURE: 1
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
+      uses: easimon/maximize-build-space@v8
       with:
         overprovision-lvm: true
         remove-dotnet: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,16 @@ jobs:
     env:
       FORCE_UNSAFE_CONFIGURE: 1
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        overprovision-lvm: true
+        remove-dotnet: true
+        remove-android: true
+        remove-haskell: true
+        remove-codeql: true
+        remove-docker-images: true
+
     - uses: actions/checkout@v3
     - if: inputs.submodule
       run: git submodule update --init --depth 1 -- ${{ inputs.submodule }}
@@ -75,6 +85,16 @@ jobs:
     env:
       FORCE_UNSAFE_CONFIGURE: 1
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        overprovision-lvm: true
+        remove-dotnet: true
+        remove-android: true
+        remove-haskell: true
+        remove-codeql: true
+        remove-docker-images: true
+
     - uses: actions/checkout@v3
     - if: inputs.submodule
       run: git submodule update --init --depth 1 -- ${{ inputs.submodule }}


### PR DESCRIPTION
Maximize build space for `build-image-uclibc` and `build-image-musl`

This'll fix `No space left on device` errors in `MiyooCFW` GitHub Actions.

e.g. https://github.com/TriForceX/MiyooCFW/actions/runs/6505699465

After Mergine this PR and update submodules in main project.

Thank you.

GitHub Actions result with this PR: https://github.com/takano32/buildroot/actions