### PR TITLE
[ACTIONS] Less verbose log for GitHub log action + change repo format for libxmlrpc package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,18 @@ jobs:
         #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_uclibc_defconfig
-        make -s sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
+        set -o pipefail
+        make sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}" 2>&1  \
+        |tee build.log   \
+        |grep ">>>"
  
+    - name: Archive build logs (uClibc)
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-logs (uClibc)
+        path: build.log
+
     - name: generate-graphs
       run: |
         cd ${{ inputs.submodule || '.' }}
@@ -120,7 +130,17 @@ jobs:
         #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_musl_defconfig
-        make -s sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
+        set -o pipefail
+        make sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}" 2>&1  \
+        |tee build.log   \
+        |grep ">>>"
+ 
+    - name: Archive build logs (musl)
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-logs (musl)
+        path: build.log
 
     - name: generate-graphs
       run: |
@@ -183,7 +203,17 @@ jobs:
       run: |
         cd ${{ inputs.submodule || '.' }}
         make miyoo_uclibc_static_defconfig
-        make -s sdk
+        set -o pipefail
+        make sdk 2>&1  \
+        |tee build.log   \
+        |grep ">>>"
+ 
+    - name: Archive build logs (uClibc static)
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-logs (uClibc static)
+        path: build.log
 
     - uses: actions/upload-artifact@v3
       with:
@@ -222,7 +252,18 @@ jobs:
       run: |
         cd ${{ inputs.submodule || '.' }}
         make miyoo_musl_static_defconfig
-        make -s sdk
+        set -o pipefail
+        make sdk 2>&1  \
+        |tee build.log   \
+        |grep ">>>"
+ 
+    - name: Archive build logs (musl static)
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-logs (musl static)
+        path: build.log
+
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_uclibc_defconfig
-        make sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
+        make -s sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
  
     - name: generate-graphs
       run: |
@@ -120,7 +120,7 @@ jobs:
         #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_musl_defconfig
-        make sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
+        make -s sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}"
 
     - name: generate-graphs
       run: |
@@ -183,7 +183,7 @@ jobs:
       run: |
         cd ${{ inputs.submodule || '.' }}
         make miyoo_uclibc_static_defconfig
-        make sdk
+        make -s sdk
 
     - uses: actions/upload-artifact@v3
       with:
@@ -222,7 +222,7 @@ jobs:
       run: |
         cd ${{ inputs.submodule || '.' }}
         make miyoo_musl_static_defconfig
-        make sdk
+        make -s sdk
 
     - uses: actions/upload-artifact@v3
       with:

--- a/package/libxmlrpc/libxmlrpc.mk
+++ b/package/libxmlrpc/libxmlrpc.mk
@@ -6,7 +6,7 @@
 
 # 1.58.02 (code/advanced@r3119)
 LIBXMLRPC_VERSION = r3119
-LIBXMLRPC_SITE = https://svn.code.sf.net/p/xmlrpc-c/code/advanced
+LIBXMLRPC_SITE = svn://svn.code.sf.net/p/xmlrpc-c/code/advanced
 LIBXMLRPC_SITE_METHOD = svn
 LIBXMLRPC_LICENSE = BSD-3-Clause (xml-rpc main code and abyss web server), BSD like (lib/expat), Python 1.5.2 license (parts of xmlrpc_base64.c)
 LIBXMLRPC_LICENSE_FILES = doc/COPYING


### PR DESCRIPTION
Logs from Buildroot are very verbose and cannot be fully displayed by the GitHub actions log viewer. So print much fewer logs to stdout + write verbose logs to the file and store them as an artefact

+ Change repo type from https to svn for libxmlrpc due to slow checkout