### PR TITLE
Prepare splash for uboot

### DIFF
--- a/board/miyoo/genimage-sdcard.cfg
+++ b/board/miyoo/genimage-sdcard.cfg
@@ -7,6 +7,7 @@ image bootfs.vfat {
 			"suniv-f1c100s-miyoo-4bit.dtb",
 			"boot.scr",
 			"boot/miyoo-boot.bmp",
+			"boot/miyoo-splash.bmp",
 			"boot/autorun.inf",
 			"boot/boot.ico",
 			"boot/console.cfg",

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -47,6 +47,7 @@ fi
 
 # Write CFW version to splash image
 convert board/miyoo/miyoo-boot.png -pointsize 12 -fill white -annotate +10+230 "v${CFW_RELEASE} ${CFW_VERSION} (${LIBC}) ${STATUS}" -alpha off -type truecolor -strip -define bmp:format=bmp4 -define bmp:subtype=RGB565 "${BINARIES_DIR}"/boot/miyoo-boot.bmp
+convert board/miyoo/miyoo-boot.png -pointsize 12 -fill white -annotate +10+230 "v${CFW_RELEASE} ${CFW_VERSION} (${LIBC}) ${STATUS}" -type Palette -colors 224 -depth 8 -compress none -verbose BMP3:"${BINARIES_DIR}"/boot/miyoo-splash.bmp
 
 # Generate MAIN BTRFS partition
 image="${BINARIES_DIR}/main.img"


### PR DESCRIPTION
Prepare splash screen for uboot with enabled video backend
uboot supports only 4, 8, or 24 bpp bitmaps

To create 8bpp bitmap:
`convert miyoo-boot.png -type Palette -colors 224 -depth 8 -compress none BMP3:miyoo-splash.bmp`

To create 24bpp bitmap:
`convert miyoo-boot.png -type truecolor miyoo-splash.bmp`

