### PR TITLE
[Retroarch] Reduce audio latency to 64ms to fix frame pacing

### DIFF
--- a/package/retroarch/0003-reduce-audio-delay-to-64.patch
+++ b/package/retroarch/0003-reduce-audio-delay-to-64.patch
@@ -1,0 +1,13 @@
+diff --git a/config.def.h b/config.def.h
+index 25f0dbe463..a4aa1cc802 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -1112,7 +1112,7 @@
+ 
+ /* Desired audio latency in milliseconds. Might not be honored
+  * if driver can't provide given latency. */
+-#if defined(ANDROID) || defined(EMSCRIPTEN) || defined(RETROFW) || defined(MIYOO)
++#if defined(ANDROID) || defined(EMSCRIPTEN) || defined(RETROFW)
+ /* For most Android devices, 64ms is way too low. */
+ #define DEFAULT_OUT_LATENCY 128
+ #define DEFAULT_IN_LATENCY 128


### PR DESCRIPTION
Reduce audio latency to 64ms to fix frame pacing