### PR TITLE
GENIMAGE/ACTIONS: automate CFW release tag & status ver.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,13 @@ jobs:
         restore-keys: |
           ${{ inputs.submodule }}-uclibc-ccache-
     
-    - name: generate cfw hash
+    - name: generate cfw hash & iteration count
       run: |
         git config --global --add safe.directory /__w/buildroot/buildroot 
-        echo "cfwsha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "cfw_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        if test $(git tag | wc -l) -ne 0; then \
+        echo "cfw_iteration=$(git rev-list --count $(git describe --tags --abbrev=0)..HEAD)" >> $GITHUB_OUTPUT; \
+        fi
       id: cfwsha
     
     - name: build
@@ -54,7 +57,7 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1
@@ -126,10 +129,13 @@ jobs:
         restore-keys: |
           ${{ inputs.submodule }}-musl-ccache-
 
-    - name: generate cfw hash
+    - name: generate cfw hash & iteration count
       run: |
         git config --global --add safe.directory /__w/buildroot/buildroot 
-        echo "cfwsha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "cfw_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        if test $(git tag | wc -l) -ne 0; then \
+        echo "cfw_iteration=$(git rev-list --count $(git describe --tags --abbrev=0)..HEAD)" >> $GITHUB_OUTPUT; \
+        fi
       id: cfwsha
 
     - name: build
@@ -140,7 +146,7 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfwsha }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk \
+        CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" \
+        APPEND_VERSION="-Dev_build$(echo ${{ github.ref_name != 'master' && github.ref_name || '' }} | sed 's/\//-/g' | sed '/./ s/^/-/')" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1
@@ -148,7 +150,9 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk \
+        CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" \
+        APPEND_VERSION="-Dev_build$(echo ${{ github.ref_name != 'master' && github.ref_name || '' }} | sed 's/\//-/g' | sed '/./ s/^/-/')" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: build image (uClibc)
-        path: ${{ inputs.submodule || '.' }}/output/images/miyoo-cfw-*.img
+        path: ${{ inputs.submodule || '.' }}/output/images/miyoo-*.img
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
         
     - uses: actions/upload-artifact@v3
@@ -168,7 +168,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: build image (musl)
-        path: ${{ inputs.submodule || '.' }}/output/images/miyoo-cfw-*.img
+        path: ${{ inputs.submodule || '.' }}/output/images/miyoo-*.img
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Buildroot
 on:
   push:
   pull_request:
+  workflow_dispatch:
   workflow_call:
     inputs:
       submodule:
@@ -26,8 +27,10 @@ jobs:
         remove-docker-images: true
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - if: inputs.submodule
-      run: git submodule update --init --depth 1 -- ${{ inputs.submodule }}
+      run: git submodule update --init -- ${{ inputs.submodule }}
   
     - name: retrieve ccache
       uses: actions/cache@v3
@@ -46,7 +49,6 @@ jobs:
     - name: build
       run: |
         cd ${{ inputs.submodule || '.' }}
-        #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_uclibc_defconfig
         CPU_N=$(getconf _NPROCESSORS_ONLN)
@@ -111,8 +113,10 @@ jobs:
         remove-docker-images: true
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - if: inputs.submodule
-      run: git submodule update --init --depth 1 -- ${{ inputs.submodule }}
+      run: git submodule update --init -- ${{ inputs.submodule }}
 
     - name: retrieve ccache
       uses: actions/cache@v3
@@ -131,7 +135,6 @@ jobs:
     - name: build
       run: |
         cd ${{ inputs.submodule || '.' }}
-        #apt update && apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion
         sudo apt update && sudo apt install -y gsfonts
         make miyoo_musl_defconfig
         CPU_N=$(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
         git config --global --add safe.directory /__w/buildroot/buildroot 
         echo "cfw_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         if test $(git tag | wc -l) -ne 0; then \
+        echo "cfw_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT; \
         echo "cfw_iteration=$(git rev-list --count $(git describe --tags --abbrev=0)..HEAD)" >> $GITHUB_OUTPUT; \
         fi
       id: cfwsha
@@ -57,7 +58,7 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1
@@ -134,6 +135,7 @@ jobs:
         git config --global --add safe.directory /__w/buildroot/buildroot 
         echo "cfw_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         if test $(git tag | wc -l) -ne 0; then \
+        echo "cfw_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT; \
         echo "cfw_iteration=$(git rev-list --count $(git describe --tags --abbrev=0)..HEAD)" >> $GITHUB_OUTPUT; \
         fi
       id: cfwsha
@@ -146,7 +148,7 @@ jobs:
         CPU_N=$(getconf _NPROCESSORS_ONLN)
         set -o pipefail
         if ! ( \
-        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
+        make -j $CPU_N sdk CFW_HASH="${{ steps.cfwsha.outputs.cfw_sha }}" CFW_TAG="${{ steps.cfwsha.outputs.cfw_tag }}" CFW_ITERATION="${{ steps.cfwsha.outputs.cfw_iteration }}" APPEND_VERSION="-Dev_build" 2>&1 \
         | tee build.log \
         | grep ">>>" \
         ); then tail -n100 build.log && exit 1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Opensource development package for Miyoo handhelds
 
 ### Install necessary packages
 ``` shell
-sudo apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion python3
+sudo apt install -y wget unzip build-essential git bc swig libncurses-dev libpython3-dev libssl-dev cpio rsync subversion python3 mercurial imagemagick btrfs-progs
 ```
 
 ### Download BSP

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -40,7 +40,10 @@ if test -n "$GIT_TAG"; then
 		elif test -n "$STATUS" ; then
 			STATUS="${STATUS}v2"
 		fi
-		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
+		if test "$STATUS" == "$CFW_RELEASE"; then
+			STATUS="BETA"
+			CFW_RELEASE="$(echo ${CFW_RELEASE} | sed 's/[0-9]$//')$(echo ${CFW_RELEASE} | grep -oE '[0-9]+$' | expr $(cat -) + 1)"
+		fi
 		APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
 	fi
 else

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -7,25 +7,31 @@ LIBC=${4}
 STARTDIR=$(pwd)
 SELFDIR=$(dirname $(realpath ${0}))
 
-# BR2 Version is tracked by git
+# Generate CFW release tag, status and append iteration count
+if test $(git tag | wc -l) -ne 0; then
+	BR2_TAG="$(git describe --tags --abbrev=0)"
+	ITERATION_VERSION="$(git rev-list --count ${BR2_TAG}..HEAD)"
+fi
+
 ## DO NOT add messages to tags, or BR2_HASH will output tag-commit instead
-BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//' | sed 's/-.*//') # also remove "-dirty" bit
+BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//' | sed 's/-.*//') # rm git tracking and "-dirty" bit
 if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
 	CFW_TYPE="buildroot_dist"
 	CFW_HASH="$BR2_HASH"
 	CFW_VERSION="BR2=${BR2_HASH}"
+	GIT_TAG="$BR2_TAG"
+	ITERATION_VERSION="$BR2_ITERATION"
 else
 	CFW_TYPE="cfw"
 	CFW_VERSION="CFW=${CFW_HASH}"
+	GIT_TAG="$CFW_TAG"
+	ITERATION_VERSION="$CFW_ITERATION"
 fi
 
-# Generate CFW release tag, status and append iteration count
-if test $(git tag | wc -l) -ne 0; then
-	GIT_TAG="$(git describe --tags --abbrev=0)"
+if test -n "$GIT_TAG"; then
 	CFW_RELEASE="$(echo ${GIT_TAG} | sed 's/-.*//')"
 	STATUS="$(echo ${GIT_TAG} | sed 's/^[^-]*-//' | tr '[:lower:]' '[:upper:]' | tr '-' 'v')"
-	ITERATION_VERSION="$(git rev-list --count ${GIT_TAG}..HEAD)"
-	if test $ITERATION_VERSION -eq 0 || test "$CFW_TYPE" == "cfw" && test -n "$CFW_ITERATION" && test $CFW_ITERATION -eq 0; then
+	if test $ITERATION_VERSION -eq 0; then
 		APPEND_VERSION=""
 		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="STABLE"; fi
 	else
@@ -35,7 +41,6 @@ if test $(git tag | wc -l) -ne 0; then
 		elif [ "$STATUS" == "BETA" ]; then
 			STATUS="${STATUS}v2"
 		fi
-		if test "$CFW_TYPE" == "cfw"; then ITERATION_VERSION="${CFW_ITERATION}"; fi
 		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
 		APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
 	fi

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -10,11 +10,10 @@ SELFDIR=$(dirname $(realpath ${0}))
 # Generate CFW release tag, status and append iteration count
 if test $(git tag | wc -l) -ne 0; then
 	BR2_TAG="$(git describe --tags --abbrev=0)"
-	ITERATION_VERSION="$(git rev-list --count ${BR2_TAG}..HEAD)"
+	BR2_ITERATION="$(git rev-list --count ${BR2_TAG}..HEAD)"
 fi
 
-## DO NOT add messages to tags, or BR2_HASH will output tag-commit instead
-BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//' | sed 's/-.*//') # rm git tracking and "-dirty" bit
+BR2_HASH="$(git rev-parse --short HEAD)" # not using print-version from BR2_VERSION_FULL
 if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
 	CFW_TYPE="buildroot_dist"
 	CFW_HASH="$BR2_HASH"
@@ -38,7 +37,7 @@ if test -n "$GIT_TAG"; then
 		if [[ "$(echo ${STATUS} | sed 's/^[^-]*v//')" =~ ^-?[0-9]+$ ]]; then
 			APPEND_VERSION="v$(echo ${STATUS} | sed 's/^[^-]*v//' | expr $(cat -) + 1)${APPEND_VERSION}"
 			STATUS="$(echo ${STATUS} | sed 's/v.*//')"
-		elif [ "$STATUS" == "BETA" ]; then
+		elif test -n "$STATUS" ; then
 			STATUS="${STATUS}v2"
 		fi
 		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
@@ -49,7 +48,7 @@ else
 	STATUS="UNKNOWN"
 fi
 
-export IMAGE_NAME="${BR2_VENDOR}-${CFW_TYPE}-${CFW_RELEASE}${CFW_HASH}_${LIBC}-${STATUS}${APPEND_VERSION}.img"
+export IMAGE_NAME="${BR2_VENDOR}-${CFW_TYPE}-${CFW_RELEASE}-${CFW_HASH}_${LIBC}-${STATUS}${APPEND_VERSION}.img"
 
 # Relocate board files for genimage-sdcard config to read (see last cmd)
 cp -r board/miyoo/boot "${BINARIES_DIR}"

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -15,7 +15,7 @@ fi
 
 BR2_HASH="$(git rev-parse --short HEAD)" # not using print-version from BR2_VERSION_FULL
 if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
-	CFW_TYPE="buildroot_dist"
+	CFW_TYPE="br2_dist"
 	CFW_HASH="$BR2_HASH"
 	CFW_VERSION="BR2=${BR2_HASH}"
 	GIT_TAG="$BR2_TAG"

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -13,7 +13,7 @@ if test $(git tag | wc -l) -ne 0; then
 	CFW_RELEASE="$(echo ${GIT_TAG} | sed 's/-.*//')"
 	STATUS="$(echo ${GIT_TAG} | sed 's/^[^-]*-//' | tr '[:lower:]' '[:upper:]' | tr '-' 'v')"
 	ITERATION_VERSION="$(git rev-list --count ${GIT_TAG}..HEAD)"
-	if test $ITERATION_VERSION -eq 0; then
+	if test $ITERATION_VERSION -eq 0 || test -n "$CFW_ITERATION" && test $CFW_ITERATION -eq 0; then
 		APPEND_VERSION=""
 		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="STABLE"; fi
 	else
@@ -23,8 +23,9 @@ if test $(git tag | wc -l) -ne 0; then
 		elif [ "$STATUS" == "BETA" ]; then
 			STATUS="${STATUS}v2"
 		fi
-		APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
+		if (test "$CFW_ITERATION" != "$ITERATION_VERSION" && test -n "$CFW_ITERATION"); then ITERATION_VERSION="${CFW_ITERATION}"; fi
 		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
+		APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
 	fi
 else
 	CFW_RELEASE="0.0.0"
@@ -34,8 +35,11 @@ fi
 # BR2 Version is tracked by git
 BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//')
 if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
+	CFW_TYPE="buildroot_dist"
+	CFW_HASH="$BR2_HASH"
 	CFW_VERSION="BR2=${BR2_HASH}"
 else
+	CFW_TYPE="cfw"
 	CFW_VERSION="CFW=${CFW_HASH}"
 fi
 

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+BR2_VENDOR=${2}
+BR2_VERSION_FULL=${3}
+LIBC=${4}
+STARTDIR=$(pwd)
+SELFDIR=$(dirname $(realpath ${0}))
+
 # Generate CFW release tag, status and append iteration count
 if test $(git tag | wc -l) -ne 0; then
 	GIT_TAG="$(git describe --tags --abbrev=0)"
@@ -8,35 +14,39 @@ if test $(git tag | wc -l) -ne 0; then
 	STATUS="$(echo ${GIT_TAG} | sed 's/^[^-]*-//' | tr '[:lower:]' '[:upper:]' | tr '-' 'v')"
 	ITERATION_VERSION="$(git rev-list --count ${GIT_TAG}..HEAD)"
 	if test $ITERATION_VERSION -eq 0; then
-			APPEND_VERSION=""
-			if test "$STATUS" == "$CFW_RELEASE"; then STATUS="STABLE"; fi
+		APPEND_VERSION=""
+		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="STABLE"; fi
 	else
-			if [[ "$(echo ${STATUS} | sed 's/^[^-]*v//')" =~ ^-?[0-9]+$ ]]; then
-					APPEND_VERSION="v$(echo ${STATUS} | sed 's/^[^-]*v//' | expr $(cat -) + 1)${APPEND_VERSION}"
-					STATUS="$(echo ${STATUS} | sed 's/v.*//')"
-			elif [ "$STATUS" == "BETA" ]; then
-					STATUS="${STATUS}v2"
-			fi
-			APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
-			if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
+		if [[ "$(echo ${STATUS} | sed 's/^[^-]*v//')" =~ ^-?[0-9]+$ ]]; then
+			APPEND_VERSION="v$(echo ${STATUS} | sed 's/^[^-]*v//' | expr $(cat -) + 1)${APPEND_VERSION}"
+			STATUS="$(echo ${STATUS} | sed 's/v.*//')"
+		elif [ "$STATUS" == "BETA" ]; then
+			STATUS="${STATUS}v2"
+		fi
+		APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
+		if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
 	fi
 else
 	CFW_RELEASE="0.0.0"
 	STATUS="UNKNOWN"
 fi
 
-# Output Image name
-BR2_VENDOR=${2}
-BR2_VERSION_FULL=${3}
-LIBC=${4}
-export IMAGE_NAME="${BR2_VENDOR}-cfw-${CFW_RELEASE}${BR2_VERSION_FULL}_${LIBC}-${STATUS}${APPEND_VERSION}.img"
+# BR2 Version is tracked by git
+BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//')
+if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
+	CFW_VERSION="BR2=${BR2_HASH}"
+else
+	CFW_VERSION="CFW=${CFW_HASH}"
+fi
 
-STARTDIR=`pwd`
-SELFDIR=`dirname \`realpath ${0}\``
+export IMAGE_NAME="${BR2_VENDOR}-${CFW_TYPE}-${CFW_RELEASE}${CFW_HASH}_${LIBC}-${STATUS}${APPEND_VERSION}.img"
 
 # Relocate board files for genimage-sdcard config to read (see last cmd)
 cp -r board/miyoo/boot "${BINARIES_DIR}"
 cp -r board/miyoo/main "${BINARIES_DIR}"
+
+# Write CFW version to splash image
+convert board/miyoo/miyoo-splash.png -pointsize 12 -fill white -annotate +10+230 "v${CFW_RELEASE} ${CFW_VERSION} (${LIBC}) ${STATUS}${APPEND_VERSION}" -type Palette -colors 224 -depth 8 -compress none -verbose BMP3:"${BINARIES_DIR}"/boot/miyoo-splash.bmp
 
 # Workaround for build apss and configs being placed in /usr/ after img generation (as we use MAIN)
 test -d "${BINARIES_DIR}/gmenu2x" && cp -r "${BINARIES_DIR}/gmenu2x/" "${BINARIES_DIR}/main/"
@@ -51,7 +61,7 @@ if test -d "${BINARIES_DIR}/retroarch"; then
 			CORE_FILE="$(echo "$file" | sed 's/.*\///')"
 			CORE_NAME="$(echo "${CORE_FILE}" | sed 's/_libretro.so//g')"
 			CORE_SCRIPT="${CORE_NAME}.sh"
-			touch $RA_WDIR/"${CORE_SCRIPT}" 
+			touch $RA_WDIR/"${CORE_SCRIPT}"
 			echo -e "#!/bin/sh\n/mnt/emus/retroarch/retroarch -L ${CORE_FILE} \"\$1\"" > $RA_WDIR/"${CORE_SCRIPT}"
 			chmod +x $RA_WDIR/"${CORE_SCRIPT}"
 			# RA_LDIR="${BINARIES_DIR}/main/gmenu2x/sections/cores"
@@ -61,17 +71,6 @@ if test -d "${BINARIES_DIR}/retroarch"; then
 		fi
 	done
 fi
-
-# BR2 Version is tracked by git
-BR2_HASH=$(echo $BR2_VERSION_FULL | sed 's/^[-]g//')
-if (test "$CFW_HASH" == "$BR2_HASH" || test -z "$CFW_HASH"); then
-	CFW_VERSION="BR2=${BR2_HASH}"
-else
-	CFW_VERSION="CFW=${CFW_HASH}"
-fi
-
-# Write CFW version to splash image
-convert board/miyoo/miyoo-splash.png -pointsize 12 -fill white -annotate +10+230 "v${CFW_RELEASE} ${CFW_VERSION} (${LIBC}) ${STATUS}${APPEND_VERSION}" -type Palette -colors 224 -depth 8 -compress none -verbose BMP3:"${BINARIES_DIR}"/boot/miyoo-splash.bmp
 
 # Generate MAIN BTRFS partition
 image="${BINARIES_DIR}/main.img"

--- a/board/miyoo/scripts/genimage.sh
+++ b/board/miyoo/scripts/genimage.sh
@@ -1,11 +1,36 @@
 #!/bin/bash
 set -e
-CFW_RELEASE="2.0.0"
-STATUS="BETAv2"
+
+# Generate CFW release tag, status and append iteration count
+if test $(git tag | wc -l) -ne 0; then
+	GIT_TAG="$(git describe --tags --abbrev=0)"
+	CFW_RELEASE="$(echo ${GIT_TAG} | sed 's/-.*//')"
+	STATUS="$(echo ${GIT_TAG} | sed 's/^[^-]*-//' | tr '[:lower:]' '[:upper:]' | tr '-' 'v')"
+	ITERATION_VERSION="$(git rev-list --count ${GIT_TAG}..HEAD)"
+	if test $ITERATION_VERSION -eq 0; then
+			APPEND_VERSION=""
+			if test "$STATUS" == "$CFW_RELEASE"; then STATUS="STABLE"; fi
+	else
+			if [[ "$(echo ${STATUS} | sed 's/^[^-]*v//')" =~ ^-?[0-9]+$ ]]; then
+					APPEND_VERSION="v$(echo ${STATUS} | sed 's/^[^-]*v//' | expr $(cat -) + 1)${APPEND_VERSION}"
+					STATUS="$(echo ${STATUS} | sed 's/v.*//')"
+			elif [ "$STATUS" == "BETA" ]; then
+					STATUS="${STATUS}v2"
+			fi
+			APPEND_VERSION="${APPEND_VERSION}-n${ITERATION_VERSION}"
+			if test "$STATUS" == "$CFW_RELEASE"; then STATUS="BETA"; fi
+	fi
+else
+	CFW_RELEASE="0.0.0"
+	STATUS="UNKNOWN"
+fi
+
+# Output Image name
 BR2_VENDOR=${2}
 BR2_VERSION_FULL=${3}
 LIBC=${4}
 export IMAGE_NAME="${BR2_VENDOR}-cfw-${CFW_RELEASE}${BR2_VERSION_FULL}_${LIBC}-${STATUS}${APPEND_VERSION}.img"
+
 STARTDIR=`pwd`
 SELFDIR=`dirname \`realpath ${0}\``
 
@@ -16,7 +41,7 @@ cp -r board/miyoo/main "${BINARIES_DIR}"
 # Workaround for build apss and configs being placed in /usr/ after img generation (as we use MAIN)
 test -d "${BINARIES_DIR}/gmenu2x" && cp -r "${BINARIES_DIR}/gmenu2x/" "${BINARIES_DIR}/main/"
 test -d "${BINARIES_DIR}/emus" && cp -r "${BINARIES_DIR}/emus/" "${BINARIES_DIR}/main/"
-if test -d "${BINARIES_DIR}/retroarch";then
+if test -d "${BINARIES_DIR}/retroarch"; then
 	rsync -avzh "${BINARIES_DIR}/retroarch/" "${BINARIES_DIR}/main/.retroarch/"
 	## Generate list of cores to be used
 	CORES_DIR="${BINARIES_DIR}/retroarch/cores"


### PR DESCRIPTION
Update `genimage.sh` to auto-generate release version from `git describe --tags`:
- if commit is a tagged release `2.0.0` then CFW is `2.0.0 STABLE`
- if commit is a tagged release `2.0.0-beta-2` then CFW is `2.0.0 BETAv2`
- if commit is not tagged then if last tag is `2.0.0-beta-2` thus CFW is `2.0.0 BETAv3-<number_of_abbrev_commits>` 
...and so on...

This also requires to update `build.yml` for CI build:
- increase `git fetch --depth` with YAML `fetch-depth = 0` (can't use fetch-tags)
- `git submodule -init` with standard settings for inputs.submodule on main repo

Roughly speaking tagging release is handled by BUILDROOT now, ~~so before doing anything on main repo with submodules, you have to first `git tag <CFW_RELEASE>` it here.~~