### PR TITLE
PACKAGE-mpg123: disable LARGE FILE STORAGE support

### DIFF
--- a/package/mpg123/mpg123.mk
+++ b/package/mpg123/mpg123.mk
@@ -81,4 +81,7 @@ else
 MPG123_CONF_OPTS += --enable-modules
 endif
 
+# the LFS wrappers brake mpg123_seek on ARM 32bit
+MPG123_CONF_OPTS += --disable-lfs-alias
+
 $(eval $(autotools-package))


### PR DESCRIPTION
This fixes `mpg123_seek()` and similar on MP players, when parsing `-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64` to make cmd (which is set by default for 32-bit platforms by buildroot). 

Description of that option from "configuration" script in MPG123 src, should clear things a bit:
`
--disable-lfs-alias disable alias wrappers for largefile bitness (mpg123seek32 or mpg123seek64 in addition to mpg123_seek, or the other way around; It is a mess, do not play with this!)
`