### PR TITLE
PACKAGE-mpg123: use LFS alias type of `long` for ARM

### DIFF
--- a/package/mpg123/mpg123.mk
+++ b/package/mpg123/mpg123.mk
@@ -20,6 +20,10 @@ MPG123_CPU = aarch64
 endif
 
 ifeq ($(BR2_arm),y)
+# the LFS wrappers brake mpg123_seek on ARM 32bit
+MPG123_CONF_OPTS += --disable-lfs-alias
+# also overwrite cflags to not pass -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64' macros
+MPG123_CONF_ENV += CPPFLAGS=" " CFLAGS=" "
 ifeq ($(or $(BR2_ARM_CPU_HAS_NEON),$(BR2_ARM_CPU_HAS_VFPV2)),y)
 MPG123_CPU = arm_fpu
 else
@@ -80,8 +84,5 @@ MPG123_CONF_OPTS += --disable-modules
 else
 MPG123_CONF_OPTS += --enable-modules
 endif
-
-# the LFS wrappers brake mpg123_seek on ARM 32bit
-MPG123_CONF_OPTS += --disable-lfs-alias
 
 $(eval $(autotools-package))


### PR DESCRIPTION
This also change in configure a "LFS alias type" from `off_t` to `long`, which is usefull for apps like `gmu` who rely on mpg123 API functions that way.
for bigger story ref.: https://sourceforge.net/p/mpg123/bugs/330/?limit=25
\---
also move whole LFS stuff to ARM 32-bit defines