### PR TITLE
PACKAGE-mpg123: force "largefile_sensitive" on arm 32bit

### DIFF
--- a/package/mpg123/mpg123.mk
+++ b/package/mpg123/mpg123.mk
@@ -22,8 +22,8 @@ endif
 ifeq ($(BR2_arm),y)
 # the LFS wrappers brake mpg123_seek on ARM 32bit
 MPG123_CONF_OPTS += --disable-lfs-alias
-# also overwrite cflags to not pass -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64' macros
-MPG123_CONF_ENV += CPPFLAGS=" " CFLAGS=" "
+# Force "largefile_sensitive" in case offset bit is not defined in libc headers e.g 'musl' or can't be detected otherwise
+MPG123_CONF_OPTS += ac_cv_sys_file_offset_bits=64
 ifeq ($(or $(BR2_ARM_CPU_HAS_NEON),$(BR2_ARM_CPU_HAS_VFPV2)),y)
 MPG123_CPU = arm_fpu
 else


### PR DESCRIPTION
Turns out _FILE_OFFSET_BITS doesn't work on musl libs where it lacks these macros in headers, so instead let us use AC_SYS_LARGEFILE from `autoconf` and define offset that way it detects OS as "largefile_sensitive".