### PR TITLE
PACKAGE-sdl_mixer: install `playmus` & `playwave` to TARGET

### DIFF
--- a/package/sdl_mixer/sdl_mixer.mk
+++ b/package/sdl_mixer/sdl_mixer.mk
@@ -77,4 +77,14 @@ else
 SDL_MIXER_CONF_OPTS += --disable-music-ogg
 endif
 
+define SDL_MIXER_INSTALL_BIN
+	$(TARGET_STRIP) --strip-unneeded \
+		$(@D)/build/playmus \
+		$(@D)/build/playwave
+	$(INSTALL) -D -m 0755 $(@D)/build/playmus $(TARGET_DIR)/usr/bin
+	$(INSTALL) -D -m 0755 $(@D)/build/playwave $(TARGET_DIR)/usr/bin
+endef
+
+SDL_MIXER_POST_INSTALL_TARGET_HOOKS += SDL_MIXER_INSTALL_BIN
+
 $(eval $(autotools-package))


### PR DESCRIPTION
Add two apps as proof of concept: [playmus](https://github.com/libsdl-org/SDL_mixer/blob/5e6d0953405cc6f8991e60fbc3fa9a3d03b402e1/playmus.c) and [playwave](https://github.com/libsdl-org/SDL_mixer/blob/5e6d0953405cc6f8991e60fbc3fa9a3d03b402e1/playwave.c). They will play anything via CLI supported by SDL_mixer in theory.