### PR TITLE
BOARD: create `/etc/opkg/opkg.conf`

### DIFF
--- a/board/miyoo/rootfs/etc/opkg/opkg.conf
+++ b/board/miyoo/rootfs/etc/opkg/opkg.conf
@@ -1,0 +1,1 @@
+option verbose_status_file 1


### PR DESCRIPTION
Show full `opkg info` for packages if run from target machine.

Might add other options, but have to review/inspect them first