### PR TITLE
Update texts on ipk manager

### DIFF
--- a/board/miyoo/boot/ipk_install.sh
+++ b/board/miyoo/boot/ipk_install.sh
@@ -31,7 +31,7 @@ if [[ ${#package_list[@]} -eq 0 ]]; then
 fi
 
 dialog --backtitle "MiyooCFW 2.0" --timeout 10 --title "IPK package manager" --colors --no-shadow --msgbox "\nSelect pkg with \Zb\Z3Y\Zn button on the list." 8 28
-until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-label "Info" --help-status --checklist "Press \Zb\Z3Y\Zn to select standalone App packages (non RetroArch) to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
+until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-label "Info" --help-status --checklist "Press \Zb\Z3Y\Zn to select standalone Apps (packages) to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
     case $? in
 	(1) btn=Cancel && break;;
 	(2)

--- a/board/miyoo/boot/ipk_install.sh
+++ b/board/miyoo/boot/ipk_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export TERM=linux
+export HELP="Info"
 WARN="
 MiyooCFW team is not responsible for any issues \
 arising from the use of third-party applications \
@@ -31,7 +32,7 @@ if [[ ${#package_list[@]} -eq 0 ]]; then
 fi
 
 dialog --backtitle "MiyooCFW 2.0" --timeout 10 --title "IPK package manager" --colors --no-shadow --msgbox "\nSelect pkg with \Zb\Z3Y\Zn button on the list." 8 28
-until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-status --checklist "Press \Zb\Z3Y\Zn to select packages to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
+until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-status --checklist "Press \Zb\Z3Y\Zn to select packages (non RetroArch) to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
     case $? in
 	(1) btn=Cancel && break;;
 	(2)

--- a/board/miyoo/boot/ipk_install.sh
+++ b/board/miyoo/boot/ipk_install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 export TERM=linux
-export HELP="Info"
 WARN="
 MiyooCFW team is not responsible for any issues \
 arising from the use of third-party applications \
@@ -32,7 +31,7 @@ if [[ ${#package_list[@]} -eq 0 ]]; then
 fi
 
 dialog --backtitle "MiyooCFW 2.0" --timeout 10 --title "IPK package manager" --colors --no-shadow --msgbox "\nSelect pkg with \Zb\Z3Y\Zn button on the list." 8 28
-until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-status --checklist "Press \Zb\Z3Y\Zn to select packages (non RetroArch) to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
+until selected_packages=$(dialog --backtitle "MiyooCFW 2.0" --title "IPK package manager" --colors --no-shadow --help-button --help-label "Info" --help-status --checklist "Press \Zb\Z3Y\Zn to select standalone App packages (non RetroArch) to install:" 20 60 15 "${package_list[@]}" 3>&1 1>&2 2>&3); do
     case $? in
 	(1) btn=Cancel && break;;
 	(2)


### PR DESCRIPTION
Basically add a small note alluding that these are packages that do not correspond to RetroArch, and change the name of the "Help" button to "Info" which would make more sense.
![image](https://github.com/user-attachments/assets/d48b4dae-8cc3-41fe-85fb-dc86185e1a60)