### PR TITLE
PKG: optimize `libretro-scummvm` & `libretro-scummvm-legacy` and strip

### DIFF
--- a/package/miyoo/retroarch/libretro-scummvm-legacy/0001-LIBRETRO-Makefile-optimize-by-reducing-engines-count.patch
+++ b/package/miyoo/retroarch/libretro-scummvm-legacy/0001-LIBRETRO-Makefile-optimize-by-reducing-engines-count.patch
@@ -1,0 +1,37 @@
+From 2a25e6b5e20fd9638d6da37fef29165eb63a6db0 Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Thu, 30 Jan 2025 21:12:31 +0100
+Subject: [PATCH 1/3] LIBRETRO-Makefile: optimize by reducing engines count
+
+also -fno-PIC
+---
+ backends/platform/libretro/build/Makefile | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/backends/platform/libretro/build/Makefile b/backends/platform/libretro/build/Makefile
+index 25d141eb551..066f6472422 100644
+--- a/backends/platform/libretro/build/Makefile
++++ b/backends/platform/libretro/build/Makefile
+@@ -283,15 +283,17 @@ else ifeq ($(platform), miyoo)
+    LD = /opt/miyoo/usr/bin/arm-linux-g++
+    AR = /opt/miyoo/usr/bin/arm-linux-ar cru
+    RANLIB = /opt/miyoo/usr/bin/arm-linux-ranlib
+-   DEFINES += -DDINGUX -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -fPIC
++   DEFINES += -DDINGUX -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -fno-PIC
+    DEFINES += -ffunction-sections -fdata-sections
+-   LDFLAGS += -shared -Wl,--gc-sections -Wl,--version-script=../link.T -fPIC
++   LDFLAGS += -shared -Wl,--gc-sections -Wl,--version-script=../link.T -fno-PIC
+    USE_VORBIS = 0
+    USE_THEORADEC = 0
+    USE_TREMOR = 1
+    USE_LIBCO  = 0
+    HAVE_MT32EMU = 0
+    NO_HIGH_DEF := 1
++   LITE := 1
++   NO_WIP := 1
+ 
+ else ifeq ($(platform), android-armv7)
+    TARGET  := $(TARGET_NAME)_libretro_android.so
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-scummvm-legacy/0002-LR-Makefile.common-mv-useful-engines-to-LITE-type.patch
+++ b/package/miyoo/retroarch/libretro-scummvm-legacy/0002-LR-Makefile.common-mv-useful-engines-to-LITE-type.patch
@@ -1,0 +1,81 @@
+From 9af918e6c23832bfe6545f3d5db8fcc6d8130948 Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Sun, 9 Feb 2025 15:09:54 +0100
+Subject: [PATCH 2/3] LR-Makefile.common: mv useful engines to LITE type
+
+---
+ backends/platform/libretro/build/Makefile.common | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/backends/platform/libretro/build/Makefile.common b/backends/platform/libretro/build/Makefile.common
+index c683e2c7e59..dabbe1c38d0 100644
+--- a/backends/platform/libretro/build/Makefile.common
++++ b/backends/platform/libretro/build/Makefile.common
+@@ -9,6 +9,7 @@ LIBRETRO_COMM_DIR = $(LIBRETRO_DIR)/libretro-common
+ ENABLED=STATIC_PLUGIN
+ 
+ ifeq ($(NO_HIGH_DEF), 1)
++ENABLE_ACCESS = $(ENABLED)
+ ENABLE_AGI = $(ENABLED)
+ ENABLE_AGOS = $(ENABLED)
+ ENABLE_CINE = $(ENABLED)
+@@ -20,10 +21,12 @@ ENABLE_GOB = $(ENABLED)
+ ENABLE_HE = $(ENABLED)
+ ENABLE_IHNM = $(ENABLED)
+ ENABLE_KYRA = $(ENABLED)
++ENABLE_LAB = $(ENABLED)
+ ENABLE_LOL = $(ENABLED)
+ ENABLE_LURE = $(ENABLED)
+ ENABLE_MADE = $(ENABLED)
+ ENABLE_PARALLACTION = $(ENABLED)
++ENABLE_PLUMBERS = $(ENABLED)
+ ENABLE_QUEEN = $(ENABLED)
+ ENABLE_SAGA = $(ENABLED)
+ ENABLE_SCI = $(ENABLED)
+@@ -46,6 +49,7 @@ ENABLE_TSAGE = $(ENABLED)
+ ENABLE_VOYEUR = $(ENABLED)
+ ENABLE_XEEN = $(ENABLED)
+ else
++ENABLE_ACCESS = $(ENABLED)
+ ENABLE_AGI = $(ENABLED)
+ ENABLE_AGOS = $(ENABLED)
+ ENABLE_AGOS2 = $(ENABLED)
+@@ -59,11 +63,13 @@ ENABLE_GROOVIE = $(ENABLED)
+ ENABLE_HE = $(ENABLED)
+ ENABLE_IHNM = $(ENABLED)
+ ENABLE_KYRA = $(ENABLED)
++ENABLE_LAB = $(ENABLED)
+ ENABLE_LOL = $(ENABLED)
+ ENABLE_LURE = $(ENABLED)
+ ENABLE_MADE = $(ENABLED)
+ ENABLE_MORTEVIELLE = $(ENABLED)
+ ENABLE_PARALLACTION = $(ENABLED)
++ENABLE_PLUMBERS = $(ENABLED)
+ ENABLE_QUEEN = $(ENABLED)
+ ENABLE_SAGA = $(ENABLED)
+ ENABLE_SCI = $(ENABLED)
+@@ -80,7 +86,6 @@ ENABLE_TOUCHE = $(ENABLED)
+ ENABLE_TUCKER = $(ENABLED)
+ 
+ ifneq ($(LITE), 1)
+-ENABLE_ACCESS = $(ENABLED)
+ ENABLE_ADL = $(ENABLED)
+ ENABLE_BBVS = $(ENABLED)
+ ENABLE_BLADERUNNER = $(ENABLED)
+@@ -95,13 +100,11 @@ ENABLE_HDB = $(ENABLED)
+ ENABLE_HUGO = $(ENABLED)
+ ENABLE_HOPKINS = $(ENABLED)
+ ENABLE_ILLUSIONS = $(ENABLED)
+-ENABLE_LAB = $(ENABLED)
+ ENABLE_MADS = $(ENABLED)
+ ENABLE_MOHAWK = $(ENABLED)
+ ENABLE_MYST = $(ENABLED)
+ ENABLE_NEVERHOOD = $(ENABLED)
+ ENABLE_PEGASUS = $(ENABLED)
+-ENABLE_PLUMBERS = $(ENABLED)
+ ENABLE_PRINCE = $(ENABLED)
+ ENABLE_RIVEN = $(ENABLED)
+ ENABLE_SUPERNOVA = $(ENABLED)
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-scummvm-legacy/0003-LIBRETRO-add-Audio-stutter-reduction-option.patch
+++ b/package/miyoo/retroarch/libretro-scummvm-legacy/0003-LIBRETRO-add-Audio-stutter-reduction-option.patch
@@ -1,0 +1,108 @@
+From 2e9a8372dd69af7346ce92f1fafea9008e4073af Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Wed, 5 Feb 2025 14:28:31 +0100
+Subject: [PATCH 3/3] LIBRETRO: add "Audio stutter reduction" option
+
+via: https://github.com/StupidHoroscope/libretro-scummvm-miyoo-backend/commit/6c3954f916bf430e7756afd8ca74618d48b56744
+---
+ backends/platform/libretro/libretro.cpp       | 33 +++++++++++++++++--
+ .../platform/libretro/libretro_core_options.h | 11 +++++++
+ 2 files changed, 41 insertions(+), 3 deletions(-)
+
+diff --git a/backends/platform/libretro/libretro.cpp b/backends/platform/libretro/libretro.cpp
+index 3a5bf84b4bc..76e3cc01144 100644
+--- a/backends/platform/libretro/libretro.cpp
++++ b/backends/platform/libretro/libretro.cpp
+@@ -55,6 +55,10 @@ static bool analog_response_is_quadratic = false;
+ static float mouse_speed = 1.0f;
+ 
+ static bool speed_hack_is_enabled = false;
++static bool audio_stutter_reduction = false;
++
++static size_t audio_buffer_length = 0;
++static uint32* audio_buffer = NULL;
+ 
+ char cmd_params[20][200];
+ char cmd_params_num;
+@@ -144,6 +148,11 @@ void retro_init (void)
+ 
+ void retro_deinit(void)
+ {
++   if (audio_buffer != NULL)
++   {
++      delete [] audio_buffer;
++      audio_buffer = NULL;
++   }
+ }
+ 
+ void parse_command_params(char* cmdline)
+@@ -258,6 +267,14 @@ static void update_variables(void)
+ 		if (strcmp(var.value, "enabled") == 0)
+ 			speed_hack_is_enabled = true;
+ 	}
++   var.key = "scummvm_audio_stutter_reduction";
++   var.value = NULL;
++   audio_stutter_reduction = true;
++	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
++	{
++		if (strcmp(var.value, "disabled") == 0)
++			audio_stutter_reduction = false;
++	}
+ }
+ 
+ static int retro_device = RETRO_DEVICE_JOYPAD;
+@@ -463,8 +480,18 @@ void retro_run (void)
+       video_cb(screen.pixels, screen.w, screen.h, screen.pitch);
+ 
+       /* Upload audio */
+-      static uint32 buf[735];
+-      int count = ((Audio::MixerImpl*)g_system->getMixer())->mixCallback((byte*)buf, 735*4);
++   // HACK: Stutter reduction locks the framerate to a max of 50, but stops crackling audio in most games
++   int samples_per_frame = 44100u / (audio_stutter_reduction ? 50u : 60u); 
++   if (audio_buffer == NULL || samples_per_frame != audio_buffer_length)
++   {
++      if (audio_buffer != NULL)
++      {
++         delete [] audio_buffer;
++      }
++      audio_buffer_length = samples_per_frame;
++      audio_buffer = new uint32[audio_buffer_length];
++   }
++   int count = ((Audio::MixerImpl*)g_system->getMixer())->mixCallback((byte*)audio_buffer, audio_buffer_length*4);
+ #if defined(_3DS)
+       /* Hack: 3DS will produce static noise
+        * unless we manually send a zeroed
+@@ -478,7 +505,7 @@ void retro_run (void)
+       }
+       else
+ #endif
+-         audio_batch_cb((int16_t*)buf, count);
++         audio_batch_cb((int16_t*)audio_buffer, count);
+    }
+ 
+ #if defined(USE_LIBCO)
+diff --git a/backends/platform/libretro/libretro_core_options.h b/backends/platform/libretro/libretro_core_options.h
+index 0fbd01e86d8..4befb6aafac 100644
+--- a/backends/platform/libretro/libretro_core_options.h
++++ b/backends/platform/libretro/libretro_core_options.h
+@@ -138,6 +138,17 @@ struct retro_core_option_definition option_defs_us[] = {
+       "disabled"
+ #endif
+    },
++   {
++      "scummvm_audio_stutter_reduction",
++      "Audio stutter reduction",
++      "Reduces audio stutter on resource-intensive games, at the cost of a slightly reduced framerate",
++      {
++         { "disabled", NULL },
++         { "enabled",  NULL },
++         { NULL, NULL },
++      },
++      "enabled"
++   },
+    { NULL, NULL, NULL, {{0}}, NULL },
+ };
+ 
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-scummvm-legacy/0003-LIBRETRO-add-Framerate-cap-option-to-reduce-audio-st.patch
+++ b/package/miyoo/retroarch/libretro-scummvm-legacy/0003-LIBRETRO-add-Framerate-cap-option-to-reduce-audio-st.patch
@@ -1,23 +1,24 @@
-From 2e9a8372dd69af7346ce92f1fafea9008e4073af Mon Sep 17 00:00:00 2001
+From 3eb8564fd92ae2939275a40ea67c3475dadd431b Mon Sep 17 00:00:00 2001
 From: Apaczer <94932128+Apaczer@users.noreply.github.com>
-Date: Wed, 5 Feb 2025 14:28:31 +0100
-Subject: [PATCH 3/3] LIBRETRO: add "Audio stutter reduction" option
+Date: Mon, 10 Feb 2025 21:28:33 +0100
+Subject: [PATCH 3/3] LIBRETRO: add "Framerate cap" option to reduce audio
+ stutter
 
-via: https://github.com/StupidHoroscope/libretro-scummvm-miyoo-backend/commit/6c3954f916bf430e7756afd8ca74618d48b56744
+via MM+ and: https://github.com/StupidHoroscope/libretro-scummvm-miyoo-backend/commit/6c3954f916bf430e7756afd8ca74618d48b56744
 ---
- backends/platform/libretro/libretro.cpp       | 33 +++++++++++++++++--
- .../platform/libretro/libretro_core_options.h | 11 +++++++
- 2 files changed, 41 insertions(+), 3 deletions(-)
+ backends/platform/libretro/libretro.cpp       | 32 +++++++++++++++++--
+ .../platform/libretro/libretro_core_options.h | 19 +++++++++++
+ 2 files changed, 48 insertions(+), 3 deletions(-)
 
 diff --git a/backends/platform/libretro/libretro.cpp b/backends/platform/libretro/libretro.cpp
-index 3a5bf84b4bc..76e3cc01144 100644
+index 3a5bf84b4bc..1668182774b 100644
 --- a/backends/platform/libretro/libretro.cpp
 +++ b/backends/platform/libretro/libretro.cpp
 @@ -55,6 +55,10 @@ static bool analog_response_is_quadratic = false;
  static float mouse_speed = 1.0f;
  
  static bool speed_hack_is_enabled = false;
-+static bool audio_stutter_reduction = false;
++static int cap_fps=50u;
 +
 +static size_t audio_buffer_length = 0;
 +static uint32* audio_buffer = NULL;
@@ -36,29 +37,28 @@ index 3a5bf84b4bc..76e3cc01144 100644
  }
  
  void parse_command_params(char* cmdline)
-@@ -258,6 +267,14 @@ static void update_variables(void)
+@@ -258,6 +267,13 @@ static void update_variables(void)
  		if (strcmp(var.value, "enabled") == 0)
  			speed_hack_is_enabled = true;
  	}
-+   var.key = "scummvm_audio_stutter_reduction";
++   var.key = "scummvm_audio_cap_fps";
 +   var.value = NULL;
-+   audio_stutter_reduction = true;
-+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-+	{
-+		if (strcmp(var.value, "disabled") == 0)
-+			audio_stutter_reduction = false;
++   cap_fps = 50u;
++   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
++   {
++      cap_fps = (int)atof(var.value);
 +	}
  }
  
  static int retro_device = RETRO_DEVICE_JOYPAD;
-@@ -463,8 +480,18 @@ void retro_run (void)
+@@ -463,8 +479,18 @@ void retro_run (void)
        video_cb(screen.pixels, screen.w, screen.h, screen.pitch);
  
        /* Upload audio */
 -      static uint32 buf[735];
 -      int count = ((Audio::MixerImpl*)g_system->getMixer())->mixCallback((byte*)buf, 735*4);
-+   // HACK: Stutter reduction locks the framerate to a max of 50, but stops crackling audio in most games
-+   int samples_per_frame = 44100u / (audio_stutter_reduction ? 50u : 60u); 
++   // HACK: Reduce audio buffer under-run by capping framerate to lower value.
++   int samples_per_frame = 44100u / (cap_fps);
 +   if (audio_buffer == NULL || samples_per_frame != audio_buffer_length)
 +   {
 +      if (audio_buffer != NULL)
@@ -72,7 +72,7 @@ index 3a5bf84b4bc..76e3cc01144 100644
  #if defined(_3DS)
        /* Hack: 3DS will produce static noise
         * unless we manually send a zeroed
-@@ -478,7 +505,7 @@ void retro_run (void)
+@@ -478,7 +504,7 @@ void retro_run (void)
        }
        else
  #endif
@@ -82,23 +82,31 @@ index 3a5bf84b4bc..76e3cc01144 100644
  
  #if defined(USE_LIBCO)
 diff --git a/backends/platform/libretro/libretro_core_options.h b/backends/platform/libretro/libretro_core_options.h
-index 0fbd01e86d8..4befb6aafac 100644
+index 0fbd01e86d8..a32c0e37529 100644
 --- a/backends/platform/libretro/libretro_core_options.h
 +++ b/backends/platform/libretro/libretro_core_options.h
-@@ -138,6 +138,17 @@ struct retro_core_option_definition option_defs_us[] = {
+@@ -138,6 +138,25 @@ struct retro_core_option_definition option_defs_us[] = {
        "disabled"
  #endif
     },
 +   {
-+      "scummvm_audio_stutter_reduction",
-+      "Audio stutter reduction",
-+      "Reduces audio stutter on resource-intensive games, at the cost of a slightly reduced framerate",
++      "scummvm_audio_cap_fps",
++      "Framerate cap",
++      "Lock max framerate on resource-intensive games, to reduce audio crackling",
 +      {
-+         { "disabled", NULL },
-+         { "enabled",  NULL },
++         { "15", NULL },
++         { "20", NULL },
++         { "25", NULL },
++         { "30", NULL },
++         { "35", NULL },
++         { "40", NULL },
++         { "45", NULL },
++         { "50", NULL },
++         { "55", NULL },
++         { "60", NULL },
 +         { NULL, NULL },
 +      },
-+      "enabled"
++      "50"
 +   },
     { NULL, NULL, NULL, {{0}}, NULL },
  };

--- a/package/miyoo/retroarch/libretro-scummvm/0002-gui-Tooltip-disable-tooltip-entirely.patch
+++ b/package/miyoo/retroarch/libretro-scummvm/0002-gui-Tooltip-disable-tooltip-entirely.patch
@@ -1,0 +1,82 @@
+From a6eecfa329b7fa39707a208e7071cb7b37ccb53f Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Fri, 31 Jan 2025 21:09:07 +0100
+Subject: [PATCH 2/4] gui/Tooltip: disable tooltip entirely
+
+it is unreliable & slow
+---
+ gui/Tooltip.cpp | 55 -------------------------------------------------
+ 1 file changed, 55 deletions(-)
+
+diff --git a/gui/Tooltip.cpp b/gui/Tooltip.cpp
+index 23e5b5f7437..ef12c467dff 100644
+--- a/gui/Tooltip.cpp
++++ b/gui/Tooltip.cpp
+@@ -37,64 +37,9 @@ Tooltip::Tooltip() :
+ }
+ 
+ void Tooltip::setup(Dialog *parent, Widget *widget, int x, int y) {
+-	assert(widget->hasTooltip());
+-
+-	_parent = parent;
+-
+-	setMouseUpdatedOnFocus(false);
+-
+-	_maxWidth = g_gui.xmlEval()->getVar("Globals.Tooltip.MaxWidth", 100);
+-	_xdelta = g_gui.xmlEval()->getVar("Globals.Tooltip.XDelta", 0);
+-	_ydelta = g_gui.xmlEval()->getVar("Globals.Tooltip.YDelta", 0);
+-	_xpadding = g_gui.xmlEval()->getVar("Globals.Tooltip.XPadding", 2);
+-	_ypadding = g_gui.xmlEval()->getVar("Globals.Tooltip.YPadding", 2);
+-
+-	const Graphics::Font *tooltipFont = g_gui.theme()->getFont(ThemeEngine::kFontStyleTooltip);
+-
+-	_wrappedLines.clear();
+-	_w = tooltipFont->wordWrapText(widget->getTooltip(), _maxWidth - _xpadding * 2, _wrappedLines) + _xpadding * 2;
+-	_h = (tooltipFont->getFontHeight() + 2) * _wrappedLines.size() + _ypadding * 2;
+-
+-	_x = MIN<int16>(parent->_x + x + _xdelta + _xpadding, g_system->getOverlayWidth() - _w - _xpadding * 2);
+-	_y = MIN<int16>(parent->_y + y + _ydelta + _ypadding, g_system->getOverlayHeight() - _h - _ypadding * 2);
+-
+-	if (g_gui.useRTL())
+-		_x = g_system->getOverlayWidth() - _w - _x + g_gui.getOverlayOffset();
+-
+-	if (ConfMan.hasKey("tts_enabled", "scummvm") &&
+-			ConfMan.getBool("tts_enabled", "scummvm")) {
+-		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
+-		if (ttsMan == nullptr)
+-			return;
+-		ttsMan->say(widget->getTooltip(), Common::TextToSpeechManager::QUEUE_NO_REPEAT);
+-	}
+ }
+ 
+ void Tooltip::drawDialog(DrawLayer layerToDraw) {
+-	int num = 0;
+-	int h = g_gui.theme()->getFontHeight(ThemeEngine::kFontStyleTooltip) + 2;
+-
+-	Dialog::drawDialog(layerToDraw);
+-
+-	int16 textX = g_gui.useRTL() ? _x - 1 - _xpadding : _x + 1 + _xpadding;
+-	int16 textY = _y + 1 + _ypadding;
+-
+-	Graphics::TextAlign textAlignment = g_gui.useRTL() ? Graphics::kTextAlignRight : Graphics::kTextAlignLeft;
+-
+-	for (Common::U32StringArray::const_iterator i = _wrappedLines.begin(); i != _wrappedLines.end(); ++i, ++num) {
+-		g_gui.theme()->drawText(
+-			Common::Rect(textX, textY + num * h, textX + _w, textY + (num + 1) * h),
+-			*i,
+-			ThemeEngine::kStateEnabled,
+-			textAlignment,
+-			ThemeEngine::kTextInversionNone,
+-			0,
+-			false,
+-			ThemeEngine::kFontStyleTooltip,
+-			ThemeEngine::kFontColorNormal,
+-			false
+-		);
+-	}
+ }
+ 
+ }
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-scummvm/0003-LIBRETRO-Makefile-optimize-by-reducing-engines-count.patch
+++ b/package/miyoo/retroarch/libretro-scummvm/0003-LIBRETRO-Makefile-optimize-by-reducing-engines-count.patch
@@ -1,0 +1,94 @@
+From 5a2e1d3ec02f976a446b94850fa3fcf260648f2b Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Mon, 3 Feb 2025 21:22:13 +0100
+Subject: [PATCH 3/4] LIBRETRO-Makefile: optimize by reducing engines count
+ (LITE)
+
+- discard HIGH_DEF engines from lite_engine.list  & inline with legacy (add ultima4)
+- add also -fno-PIC
+
+Update lite_engines.list
+---
+ backends/platform/libretro/Makefile          |  5 +++--
+ backends/platform/libretro/lite_engines.list | 22 +++++++++++++-------
+ 2 files changed, 18 insertions(+), 9 deletions(-)
+
+diff --git a/backends/platform/libretro/Makefile b/backends/platform/libretro/Makefile
+index af2063fef82..c66c6cccfa0 100644
+--- a/backends/platform/libretro/Makefile
++++ b/backends/platform/libretro/Makefile
+@@ -280,9 +280,9 @@ else ifeq ($(platform), miyoo)
+    LD = /opt/miyoo/usr/bin/arm-linux-g++
+    AR = /opt/miyoo/usr/bin/arm-linux-ar cru
+    RANLIB = /opt/miyoo/usr/bin/arm-linux-ranlib
+-   DEFINES += -DDINGUX -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -fPIC
++   DEFINES += -DDINGUX -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -fno-PIC
+    DEFINES += -ffunction-sections -fdata-sections -DDEFAULT_PERF_TUNER -DREDUCE_MEMORY_USAGE -DUNCACHED_PLUGINS
+-   LDFLAGS += -shared -Wl,--gc-sections -Wl,--version-script=$(ROOT_PATH)/link.T -fPIC
++   LDFLAGS += -shared -Wl,--gc-sections -Wl,--version-script=$(ROOT_PATH)/link.T -fno-PIC
+    USE_VORBIS = 0
+    USE_THEORADEC = 0
+    USE_TREMOR = 1
+@@ -290,6 +290,7 @@ else ifeq ($(platform), miyoo)
+    USE_CURL = 0
+    USE_MT32EMU = 0
+    USE_HIGHRES := 0
++   LITE := 1
+ 
+ # MIYOOMINI
+ else ifeq ($(platform), miyoomini)
+diff --git a/backends/platform/libretro/lite_engines.list b/backends/platform/libretro/lite_engines.list
+index bc681b60598..efb6d85f6e8 100644
+--- a/backends/platform/libretro/lite_engines.list
++++ b/backends/platform/libretro/lite_engines.list
+@@ -1,32 +1,40 @@
++access
+ agi
+ agos
+-agos2
+ cine
+ cruise
+ draci
+ drascula
+ eob
+ gob
+-groovie
+ he
+ ihnm
+ kyra
++lab
+ lol
+ lure
+ made
+-mortevielle
+ parallaction
++plumbers
+ queen
+ saga
+ sci
+-sci32
+ scumm
+ scumm_7_8
+ sherlock
+ sky
+-sword1
+-sword2
+ teenagent
+ tinsel
+-touche
+ tucker
++bbvs
++cge
++cge2
++dreamweb
++hugo
++illusions
++mads
++supernova
++tsage
++ultima4
++voyeur
++xeen
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-scummvm/0004-LIBRETRO-core-options-cap-frames-15Hz-and-samprate-4.patch
+++ b/package/miyoo/retroarch/libretro-scummvm/0004-LIBRETRO-core-options-cap-frames-15Hz-and-samprate-4.patch
@@ -1,0 +1,49 @@
+From 8f24612c205b379a65467c55823341515a14e83f Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Tue, 4 Feb 2025 22:45:05 +0100
+Subject: [PATCH 4/4] LIBRETRO-core-options: cap frames=15Hz and
+ samprate=44,1kHz
+
+due to capped fps, increase also "Gamepad Cursor Speed"
+---
+ .../platform/libretro/include/libretro-core-options.h     | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/backends/platform/libretro/include/libretro-core-options.h b/backends/platform/libretro/include/libretro-core-options.h
+index 0c959b78da8..816883bc7c9 100644
+--- a/backends/platform/libretro/include/libretro-core-options.h
++++ b/backends/platform/libretro/include/libretro-core-options.h
+@@ -128,7 +128,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+ 			{"3.0", NULL},
+ 			{NULL, NULL},
+ 		},
+-		"1.0"
++		"2.5"
+ 	},
+ 	{
+ 		"scummvm_gamepad_cursor_acceleration_time",
+@@ -247,9 +247,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+ 			{ "50 Hz", NULL },
+ 			{ "30 Hz", NULL },
+ 			{ "25 Hz", NULL },
++			{ "15 Hz", NULL },
++			{ "10 Hz", NULL },
+ 			{ NULL, NULL },
+ 		},
+-		"disabled"
++		"15 Hz"
+ 	},
+ 	{
+ 		"scummvm_samplerate",
+@@ -263,7 +265,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+ 			{ "44100 Hz", NULL },
+ 			{ NULL, NULL },
+ 		},
+-		"48000 Hz"
++		"44100 Hz"
+ 	},
+ 	/* Button mappings */
+ 	{
+-- 
+2.45.2.windows.1
+


### PR DESCRIPTION
PKG: optimize `libretro-scummvm-legacy`:
- reduce number of linked engines (only LITE & no WIP)
- cap framerate & increase audio_buffer (lr-option)

PKG: optimize `libretro-scummvm`
- disable Tooltip
- reduce engines count (inline with legacy)
- cap framerate->50Hz & samplerate-> 44100Hz

This meens no following engines will be available (before possibly present):
- non LITE (modded upstream & pure legacy):
  - access
  - lab
  - plumbers

- WIP (legacy):
  - avalanche
  - chewy
  - cryo
  - cstime
  - dm
  - glk
  - lastexpress
  - lilliput
  - macventure
  - mutationofjb
  - sludge
  - startrek
  - wage

- WIP (uptream):
  -  avalanche
  -  chamber
  -  cryo
  -  dm
  -  immortal
  -  lilliput
  -  mads
  -  mutationofjb
  -  sludge
  -  startrek
  -  ultima1 (ultima4 should be available of all)

---
I'm still investigeting what should be included (playable) in our builds, or should we split those into second ScummVM core (would mean a total of 4 cores!). The mainstream ScummVM with recent changes has impacted badly performance, same on standalone (not present however in 2.8.0) so still debatable should we include dev-2.10.0 at all.