### PR TITLE
PKG: lr-pcsx_rearmed: default to 57 clock + other custom fixes

### DIFF
--- a/package/miyoo/retroarch/libretro-pcsx_rearmed/0002-LIBRETRO-update-core_options.patch
+++ b/package/miyoo/retroarch/libretro-pcsx_rearmed/0002-LIBRETRO-update-core_options.patch
@@ -1,27 +1,30 @@
-From 958a3a4c41917a61dbfb51c3d7e15266110f8a58 Mon Sep 17 00:00:00 2001
+From 7525d68bf55ffa4f2af7ad173ff32bced699bd69 Mon Sep 17 00:00:00 2001
 From: Apaczer <94932128+Apaczer@users.noreply.github.com>
 Date: Sat, 15 Mar 2025 13:56:30 +0100
 Subject: [PATCH] LIBRETRO: update core_options
 
-- add extra low CPU values (def 40)
+- correct description of "auto" CPU -> aka 57%
 - disable dithering
 - enable fast_lighting
 - enable frameskip (def: auto_threshold 60%)
 ---
- frontend/libretro_core_options.h | 32 ++++++++++++++++++++++++++------
- 1 file changed, 26 insertions(+), 6 deletions(-)
+ frontend/libretro_core_options.h | 34 +++++++++++++++++++++++---------
+ 1 file changed, 25 insertions(+), 9 deletions(-)
 
 diff --git a/frontend/libretro_core_options.h b/frontend/libretro_core_options.h
-index 8c457582..8cb42c0e 100644
+index 8c457582..60229dc6 100644
 --- a/frontend/libretro_core_options.h
 +++ b/frontend/libretro_core_options.h
-@@ -233,13 +233,33 @@ struct retro_core_option_v2_definition option_defs_us[] = {
- #if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
-       " Default is 50."
- #else
+@@ -230,16 +230,32 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       "PSX CPU Clock Speed (%)",
+       NULL,
+       "Overclock or under-clock the PSX CPU. The value has to be lower than 100 because of some slowdowns (cache misses, hw access penalties, etc.) that are not emulated. Try adjusting this if the game is too slow, too fast or hangs."
+-#if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
+-      " Default is 50."
+-#else
 -      " Default is 57."
-+      " Default is 40."
- #endif
+-#endif
++      " Default is 57 (auto)."
        ,
        NULL,
        "system",
@@ -50,16 +53,7 @@ index 8c457582..8cb42c0e 100644
           { "30",  NULL },
           { "31",  NULL },
           { "32",  NULL },
-@@ -313,7 +333,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
-          { "100", NULL },
-          { NULL, NULL },
-       },
--      "auto",
-+      "40",
-    },
-    {
-       "pcsx_rearmed_dithering",
-@@ -328,7 +348,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -328,7 +344,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
           { "force",    "Force" },
           { NULL, NULL },
        },
@@ -68,7 +62,7 @@ index 8c457582..8cb42c0e 100644
        "disabled",
  #else
        "enabled",
-@@ -365,7 +385,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -365,7 +381,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
           { "fixed_interval", "Fixed Interval" },
           { NULL, NULL },
        },
@@ -77,7 +71,7 @@ index 8c457582..8cb42c0e 100644
     },
     {
        "pcsx_rearmed_frameskip_threshold",
-@@ -393,7 +413,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -393,7 +409,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
           { "60", NULL },
           { NULL, NULL },
        },
@@ -86,7 +80,7 @@ index 8c457582..8cb42c0e 100644
     },
     {
        "pcsx_rearmed_frameskip_interval",
-@@ -793,7 +813,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -793,7 +809,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
           { "enabled",  NULL },
           { NULL, NULL},
        },

--- a/package/miyoo/retroarch/libretro-pcsx_rearmed/0004-LIBRETRO-rm-UNAI-Hi-Res-Downscaling-option.patch
+++ b/package/miyoo/retroarch/libretro-pcsx_rearmed/0004-LIBRETRO-rm-UNAI-Hi-Res-Downscaling-option.patch
@@ -1,0 +1,72 @@
+From 890efc2cd52b681ea43da1dc6d4be25ebcc9bcf0 Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Sat, 23 Aug 2025 22:11:35 +0200
+Subject: [PATCH] LIBRETRO: rm UNAI "Hi-Res Downscaling" option
+
+broken in RetroArch frontend (just use aspect-ratio instead)
+---
+ frontend/libretro.c              | 11 -----------
+ frontend/libretro_core_options.h | 18 ------------------
+ 2 files changed, 29 deletions(-)
+
+diff --git a/frontend/libretro.c b/frontend/libretro.c
+index 58f72299..38f3019c 100644
+--- a/frontend/libretro.c
++++ b/frontend/libretro.c
+@@ -926,7 +926,6 @@ static bool update_option_visibility(void)
+             "pcsx_rearmed_gpu_unai_interlace",
+             "pcsx_rearmed_gpu_unai_lighting",
+             "pcsx_rearmed_gpu_unai_fast_lighting",
+-            "pcsx_rearmed_gpu_unai_scale_hires",
+          };
+ 
+          option_display.visible = show_advanced_gpu_unai_settings;
+@@ -2700,16 +2699,6 @@ static void update_variables(bool in_flight)
+          pl_rearmed_cbs.gpu_unai.blending = 1;
+    }
+ 
+-   var.key = "pcsx_rearmed_gpu_unai_scale_hires";
+-   var.value = NULL;
+-
+-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+-   {
+-      if (strcmp(var.value, "disabled") == 0)
+-         pl_rearmed_cbs.gpu_unai.scale_hires = 0;
+-      else if (strcmp(var.value, "enabled") == 0)
+-         pl_rearmed_cbs.gpu_unai.scale_hires = 1;
+-   }
+ #endif // GPU_UNAI
+ 
+    var.value = NULL;
+diff --git a/frontend/libretro_core_options.h b/frontend/libretro_core_options.h
+index 118b8e96..782e4512 100644
+--- a/frontend/libretro_core_options.h
++++ b/frontend/libretro_core_options.h
+@@ -825,24 +825,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       },
+       "enabled",
+    },
+-   {
+-      "pcsx_rearmed_gpu_unai_scale_hires",
+-      "(GPU) Hi-Res Downscaling",
+-      "Hi-Res Downscaling",
+-      "When enabled, games that run in high resolution video modes (480i, 512i) will be downscaled to 320x240. Can improve performance, and is recommended on devices with native 240p display resolutions.",
+-      NULL,
+-      "gpu_unai",
+-      {
+-         { "disabled", NULL },
+-         { "enabled",  NULL },
+-         { NULL, NULL},
+-      },
+-#ifdef _MIYOO
+-      "enabled",
+-#else
+-      "disabled",
+-#endif
+-   },
+ #endif /* GPU_UNAI */
+    {
+       "pcsx_rearmed_spu_reverb",
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-pcsx_rearmed/0005-gpulib-gpu-rm-dubious-cond.-for-frameskip.set.patch
+++ b/package/miyoo/retroarch/libretro-pcsx_rearmed/0005-gpulib-gpu-rm-dubious-cond.-for-frameskip.set.patch
@@ -1,0 +1,33 @@
+From 2dd2fb25011ef28f755e5e8da371b443cd522504 Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Wed, 18 Jun 2025 23:34:59 +0200
+Subject: [PATCH] gpulib/gpu: rm dubious cond. for frameskip.set
+
+restore it for some games e.g. Tekken 3
+---
+ plugins/gpulib/gpu.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/plugins/gpulib/gpu.c b/plugins/gpulib/gpu.c
+index 8c1b8e85..d2e8fed9 100644
+--- a/plugins/gpulib/gpu.c
++++ b/plugins/gpulib/gpu.c
+@@ -342,7 +342,6 @@ void GPUwriteStatus(uint32_t data)
+       break;
+     case 0x05:
+       src_x = data & 0x3ff; src_y = (data >> 10) & 0x1ff;
+-      if (src_x != gpu.screen.src_x || src_y != gpu.screen.src_y) {
+         gpu.screen.src_x = src_x;
+         gpu.screen.src_y = src_y;
+         renderer_notify_scanout_change(src_x, src_y);
+@@ -353,7 +352,6 @@ void GPUwriteStatus(uint32_t data)
+             gpu.frameskip.last_flip_frame = *gpu.state.frame_count;
+           }
+         }
+-      }
+       break;
+     case 0x06:
+       gpu.screen.x1 = data & 0xfff;
+-- 
+2.45.2.windows.1
+


### PR DESCRIPTION
 for HAVE_PRE_ARMV7 it assumed that 50 is a reliable underclocking CPU value.
 
 Let us use it instead of "auto" which seems to be defaulting to 57 (thus 175 cycles multiplier via `CYCLE_MULT_DEFAULT`)