### PR TITLE
BOARD-genim.cfg: revert gpt reloc. outside uboot

### DIFF
--- a/board/miyoo/genimage-sdcard.cfg
+++ b/board/miyoo/genimage-sdcard.cfg
@@ -23,10 +23,7 @@ image bootfs.vfat {
 
 image ${IMAGE_NAME:-miyoo-cfw-2.0.0.img} {
 	hdimage {
-		# for root=PARTLABEL support
 		partition-table-type = gpt
-		# default GPT location conflicts with bootloaders, move it after
-		gpt-location = 1M
 	}
 
 	partition u-boot {


### PR DESCRIPTION
no need since we fit into 7KB which doesn't conflict with disk's LBA layout