### PR TITLE
PKG-lr-fake08: fix TARGET install path

### DIFF
--- a/package/miyoo/retroarch/libretro-fake08/libretro-fake08.mk
+++ b/package/miyoo/retroarch/libretro-fake08/libretro-fake08.mk
@@ -22,7 +22,7 @@ endef
 define LIBRETRO_FAKE08_INSTALL_TARGET_CMDS
     mkdir -p "${BINARIES_DIR}/retroarch/cores"
 	$(INSTALL) -D $(@D)/platform/libretro/fake08_libretro.so \
-		$(TARGET_DIR)/usr/lib/libretro/fake08_libretro.so
+		${BINARIES_DIR}/retroarch/cores/fake08_libretro.so
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
the *.so core and launch script should be present now