### PR TITLE
BOARD: update `usb-mode` & rm deprecated usb scripts

### DIFF
--- a/board/miyoo/main/gmenu2x/sections/applications/usb-hid
+++ b/board/miyoo/main/gmenu2x/sections/applications/usb-hid
@@ -1,5 +1,0 @@
-title=USB HID
-description=USB HID PC gamepad
-exec=/usr/bin/usb-mode
-params=hid
-manual=/mnt/manuals/usb-hid.man.txt

--- a/board/miyoo/main/gmenu2x/sections/applications/usb-host
+++ b/board/miyoo/main/gmenu2x/sections/applications/usb-host
@@ -1,4 +1,0 @@
-title=USB Host
-description=USB Host mode
-exec=/usr/bin/usb-mode
-params=host

--- a/board/miyoo/main/gmenu2x/sections/applications/usb-mtd
+++ b/board/miyoo/main/gmenu2x/sections/applications/usb-mtd
@@ -1,4 +1,0 @@
-title=USB MTD
-description=USB MTD mass storage
-exec=/usr/bin/usb-mode
-params=mtp umtprd

--- a/board/miyoo/main/gmenu2x/sections/applications/usb-network
+++ b/board/miyoo/main/gmenu2x/sections/applications/usb-network
@@ -1,4 +1,0 @@
-title=USB Network
-description=IP:192.168.137.1
-exec=/usr/bin/usb-mode
-params=net

--- a/board/miyoo/main/gmenu2x/sections/applications/usb-serial-console
+++ b/board/miyoo/main/gmenu2x/sections/applications/usb-serial-console
@@ -1,4 +1,0 @@
-title=USB serial console
-description=USB Serial console
-exec=/usr/bin/usb-mode
-params=serial

--- a/board/miyoo/main/options.cfg
+++ b/board/miyoo/main/options.cfg
@@ -3,11 +3,12 @@ DEBUG=0
 DEBUG_GMENU2X=0
 DEBUG_UMTPR=0
 FIRSTBOOT=0
-FS_CHECK=1 
-BOOT_LOGO=1 
+FS_CHECK=1
+BOOT_LOGO=1
 FLIP= (put 0 or 1 to overwrite)
 INVERT= (put 0 or 1 to overwrite)
-TVMODE=0 
+TVMODE=0
 HOTKEY_CUSTOM=1
+USB_OTG=1
 
 Only "0" and "1" are accepted values

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -32,9 +32,9 @@ if test "x${DEBUG_MSG}" == "xyes" || test "x${DEBUG_GMENU2X}" == "xyes" || test 
 	LOGS_TEMP=$(mktemp)
 fi
 
-export LOGS # so that subshells can use this as well
-export LOGS_TEMP
-export GMENU2X_LOGS
+export LOGS LOGS_TEMP # so that subshells can use this as well
+export UMTPR_LOGS GMENU2X_LOGS
+export DEBUG_MSG DEBUG_UMTPR DEBUG_GMENU2X
 
 if test "x${DEBUG_MSG}" == "xyes"; then
 	echo -e "\e[0m"    # normal foreground color
@@ -50,6 +50,7 @@ restore_temp_log_func(){
 		cat ${LOGS_TEMP} >> ${LOGS}
 	fi
 	LOGS_TEMP=$(mktemp)
+	export LOGS_TEMP
 }
 
 ! test -r "${HOME}/options.cfg"\
@@ -166,18 +167,11 @@ if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
 	if test -r "${HOME}/.usbmode"; then
 		source ${HOME}/.usbmode
 	else
-		USB_MODE="mtp"
+		USB_MODE="mtp" # default setup
 	fi
 	echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
 	usb-mode ${USB_MODE} 2>&1 | tee -a "${LOGS}"
 	export USB_MODE
-	if test "${USB_MODE}" == "mtp"; then
-		if test "x${DEBUG_UMTPR}" == "xyes"; then
-			umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
-		else
-			umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
-		fi
-	fi
 fi
 
 echo "Boot!" >> "${LOGS}"

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -162,25 +162,27 @@ else
 fi
 
 # load usb modules & gadget
-modprobe sunxi 2>&1 | tee -a "${LOGS}"
-modprobe usb_f_fs 2>&1 | tee -a "${LOGS}"
-if test -r "${HOME}/.usbmode"; then
-	source ${HOME}/.usbmode
-else
-	USB_MODE="mtp"
-fi
-echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
-usb-mode ${USB_MODE} main 2>&1 | tee -a "${LOGS}"
-export USB_MODE
-if test "x${DEBUG_UMTPR}" == "xyes"; then
-	umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
-else
-	umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
-fi
+if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
+	modprobe sunxi 2>&1 | tee -a "${LOGS}"
+	modprobe usb_f_fs 2>&1 | tee -a "${LOGS}"
+	if test -r "${HOME}/.usbmode"; then
+		source ${HOME}/.usbmode
+	else
+		USB_MODE="mtp"
+	fi
+	echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
+	usb-mode ${USB_MODE} main 2>&1 | tee -a "${LOGS}"
+	export USB_MODE
+	if test "x${DEBUG_UMTPR}" == "xyes"; then
+		umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
+	else
+		umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
+	fi
 
-sleep 1
-ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/g2/UDC
-echo "Current UDC list=$(cat /sys/kernel/config/usb_gadget/g2/UDC)" >> "${LOGS}"
+	sleep 1
+	ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/g2/UDC
+	echo "Current UDC list=$(cat /sys/kernel/config/usb_gadget/g2/UDC)" >> "${LOGS}"
+fi
 
 echo "Boot!" >> "${LOGS}"
 echo "Handheld type is ${CONSOLE_VARIANT}" >> "${LOGS}"

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -178,7 +178,6 @@ if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
 			umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
 		fi
 	fi
-	echo "Current UDC list=$(cat /sys/kernel/config/usb_gadget/g2/UDC)" >> "${LOGS}"
 fi
 
 echo "Boot!" >> "${LOGS}"

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -163,24 +163,19 @@ fi
 
 # load usb modules & gadget
 if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
-	modprobe sunxi 2>&1 | tee -a "${LOGS}"
-	modprobe usb_f_fs 2>&1 | tee -a "${LOGS}"
 	if test -r "${HOME}/.usbmode"; then
 		source ${HOME}/.usbmode
 	else
 		USB_MODE="mtp"
 	fi
 	echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
-	usb-mode ${USB_MODE} main 2>&1 | tee -a "${LOGS}"
+	usb-mode ${USB_MODE} 2>&1 | tee -a "${LOGS}"
 	export USB_MODE
 	if test "x${DEBUG_UMTPR}" == "xyes"; then
 		umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
 	else
 		umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
 	fi
-
-	sleep 1
-	ls /sys/class/udc/ > /sys/kernel/config/usb_gadget/g2/UDC
 	echo "Current UDC list=$(cat /sys/kernel/config/usb_gadget/g2/UDC)" >> "${LOGS}"
 fi
 

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -163,13 +163,13 @@ fi
 
 # load usb modules & gadget
 modprobe sunxi 2>&1 | tee -a "${LOGS}"
-echo "Loading USB default MTP gadget" >> "${LOGS}"
-usb-mode 2>&1 | tee -a "${LOGS}"
+echo "Loading USB default gadget" >> "${LOGS}"
 if test -r "${HOME}/.usbmode"; then
 	source ${HOME}/.usbmode
 else
-	USB_MODE="unknown"
+	USB_MODE="mtp"
 fi
+usb-mode ${USB_MODE} main 2>&1 | tee -a "${LOGS}"
 export USB_MODE
 if test "x${DEBUG_UMTPR}" == "xyes"; then
 	umtprd-debug >> "${LOGS_TEMP}" 2>&1 &

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -79,11 +79,11 @@ if test -r "${HOME}/tvout"; then
 	echo 1 > /sys/class/vtconsole/vtcon1/bind
 	modprobe -r $video 2>&1 | tee -a "${LOGS}"
 else
-	if ((test -r "${HOME}/.backlight.bak")); then
+	if (test -r "${HOME}/.backlight.bak"); then
 		mv ${HOME}/.backlight.bak ${HOME}/.backlight.conf
 	fi
 	# MODULES_CUSTOM scripting
-	if (!(test -r "${BOOTDIR}/modules.custom.sh") || !(grep -sq MODULES_CUSTOM\=\1 "${HOME}/options.cfg")); then
+	if ( ! (test -r "${BOOTDIR}/modules.custom.sh") || ! (grep -sq MODULES_CUSTOM\=\1 "${HOME}/options.cfg")); then
 		# Load video module read from uEnv.txt & defined by variant in console.cfg
 		#FLIP & INVERT options.cfg setting
 		flip=$(grep -o FLIP=[0-1] "${HOME}/options.cfg" | tr '[:upper:]' '[:lower:]')
@@ -114,7 +114,7 @@ elif test -r "${HOME}/firstboot.completed"; then
 	rm "${HOME}/firstboot.completed"
 fi
 
-if !(grep -sq FS_CHECK\=\0 "${HOME}/options.cfg"); then
+if ! (grep -sq FS_CHECK\=\0 "${HOME}/options.cfg"); then
 ##Check if BOOT (FAT16) is flagged as "dirty", and if so unmount, repair, remount
 	if dmesg | grep "mmcblk0p1" > /dev/null;  then
 		echo -e "\e[31mDirty sectors detected.\e[0m" | tee -a "${LOGS}"
@@ -159,7 +159,7 @@ else
 fi
 
 # load usb modules & gadget
-if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
+if ! (grep -sq USB_OTG\=\0 "${HOME}/options.cfg"); then
 	if test -r "${HOME}/.usbmode"; then
 		source ${HOME}/.usbmode
 	else
@@ -182,7 +182,7 @@ else
 fi
 
 # run boot logo animation
-if (!(grep -sq BOOT_LOGO\=\0 "${HOME}/options.cfg")); then
+if ! (grep -sq BOOT_LOGO\=\0 "${HOME}/options.cfg"); then
 	${BOOTLOGO} >> "${LOGS}" 2>&1
 fi
 
@@ -209,7 +209,7 @@ do
 		else
 			./gmenu2x >> "${GMENU2X_LOGS}" 2>&1
 		fi
-		if (test -r "${HOME}/.usbmode" && !(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
+		if (test -r "${HOME}/.usbmode" && ! (grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
 		 	source ${HOME}/.usbmode
 			export USB_MODE
 		fi

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -165,6 +165,12 @@ fi
 modprobe sunxi 2>&1 | tee -a "${LOGS}"
 echo "Loading USB default MTP gadget" >> "${LOGS}"
 usb-mode 2>&1 | tee -a "${LOGS}"
+if test -r "${HOME}/.usbmode"; then
+	source ${HOME}/.usbmode
+else
+	USB_MODE="unknown"
+fi
+export USB_MODE
 if test "x${DEBUG_UMTPR}" == "xyes"; then
 	umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
 else
@@ -214,6 +220,8 @@ do
 		else
 			./gmenu2x >> "${GMENU2X_LOGS}" 2>&1
 		fi
+		test -r "${BOOTDIR}/.usbmode"\
+		 && source ${HOME}/.usbmode
 		test "x${DEBUG_UMTPR}" == "xyes"\
 		 && restore_temp_log_func
 	fi

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -163,12 +163,13 @@ fi
 
 # load usb modules & gadget
 modprobe sunxi 2>&1 | tee -a "${LOGS}"
-echo "Loading USB default gadget" >> "${LOGS}"
+modprobe usb_f_fs 2>&1 | tee -a "${LOGS}"
 if test -r "${HOME}/.usbmode"; then
 	source ${HOME}/.usbmode
 else
 	USB_MODE="mtp"
 fi
+echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
 usb-mode ${USB_MODE} main 2>&1 | tee -a "${LOGS}"
 export USB_MODE
 if test "x${DEBUG_UMTPR}" == "xyes"; then

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -28,7 +28,7 @@ if (grep -sq DEBUG_UMTPR\=\1 "${HOME}/options.cfg"); then
 	UMTPR_LOGS="${HOME}/log_umtpr.txt"
 fi
 
-if test "x${DEBUG_MSG}" == "xyes" || test "x${DEBUG_GMENU2X}" == "xyes" || test "x${DEBUG_UMTPR}" == "xyes"; then
+if test "x${DEBUG_MSG}" == "xyes" || test "x${DEBUG_GMENU2X}" == "xyes"; then
 	LOGS_TEMP=$(mktemp)
 fi
 
@@ -44,11 +44,7 @@ else
 fi
 
 restore_temp_log_func(){
-	if test "x${DEBUG_UMTPR}" == "xyes"; then
-		cat ${LOGS_TEMP} >> ${UMTPR_LOGS}
-	else
-		cat ${LOGS_TEMP} >> ${LOGS}
-	fi
+	cat ${LOGS_TEMP} >> ${LOGS}
 	LOGS_TEMP=$(mktemp)
 	export LOGS_TEMP
 }
@@ -217,7 +213,7 @@ do
 		 	source ${HOME}/.usbmode
 			export USB_MODE
 		fi
-		test "x${DEBUG_UMTPR}" == "xyes"\
+		test "x${DEBUG_MSG}" == "xyes"\
 		 && restore_temp_log_func
 	fi
 	clear

--- a/board/miyoo/rootfs/etc/main
+++ b/board/miyoo/rootfs/etc/main
@@ -171,10 +171,12 @@ if (!(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
 	echo "Loading USB ${USB_MODE} default gadget" >> "${LOGS}"
 	usb-mode ${USB_MODE} 2>&1 | tee -a "${LOGS}"
 	export USB_MODE
-	if test "x${DEBUG_UMTPR}" == "xyes"; then
-		umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
-	else
-		umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
+	if test "${USB_MODE}" == "mtp"; then
+		if test "x${DEBUG_UMTPR}" == "xyes"; then
+			umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
+		else
+			umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's running in bg the stdout/stderr redirecction is constantly active, may brake unmounting so logging here to /dev/null
+		fi
 	fi
 	echo "Current UDC list=$(cat /sys/kernel/config/usb_gadget/g2/UDC)" >> "${LOGS}"
 fi
@@ -218,8 +220,10 @@ do
 		else
 			./gmenu2x >> "${GMENU2X_LOGS}" 2>&1
 		fi
-		test -r "${BOOTDIR}/.usbmode"\
-		 && source ${HOME}/.usbmode
+		if (test -r "${HOME}/.usbmode" && !(grep -sq USB_OTG\=\0 "${HOME}/options.cfg")); then
+		 	source ${HOME}/.usbmode
+			export USB_MODE
+		fi
 		test "x${DEBUG_UMTPR}" == "xyes"\
 		 && restore_temp_log_func
 	fi

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -1,8 +1,8 @@
 #!/bin/busybox sh
 
 # ARGS
-USB_MODE="${1}"
-MTP_APP="${2}"
+USB_MODE="${1}" # mtp(default no-arg); hid; serial; net; host
+MTP_APP="${2}" # umtprd
 
 # Global variables
 SYSDIR=/sys/kernel/config/usb_gadget
@@ -164,7 +164,7 @@ usb_configs_func(){
 	fi
 }
 
-### MTP/MTD (default)###
+### MTP/MTD (default) ###
 if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
 	echo "Starting USB-MTP mode"
 	test -z $USB_MODE \
@@ -173,6 +173,9 @@ if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
 	if ! test -z $USB_MODE; then
 	# omit removing gadgets in default non-arg run
 		rm_gadget_func
+	else
+	# define envar if empty
+		USB_MODE="mtp"
 	fi
 
 	usb_configs_func
@@ -183,16 +186,20 @@ if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
 		else
 			umtprd &
 		fi
+	elif test -z ${MTP_APP}; then
+		echo "Please run uMTP-Responder in bg for working MTP"
+	else
+		echo "ERROR: Unknown MTP_APP=${MTP_APP} in 2nd arg"
+		exit 1
 	fi
 	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
-	
+
 	usb_mode_func
 	sleep 1
-fi
 
 ### HID ###
-if test "${USB_MODE}" == "hid"; then
+elif test "${USB_MODE}" == "hid"; then
 	echo "Starting USB-HID mode"
 	usb_mode_func peripheral
 	rm_gadget_func
@@ -209,10 +216,9 @@ if test "${USB_MODE}" == "hid"; then
 	modprobe -r usb_f_hid
 	modprobe -r evdev
 	modprobe -r uinput
-fi
 
 ### Serial Console ###
-if test "${USB_MODE}" == "serial"; then
+elif test "${USB_MODE}" == "serial"; then
 	echo "Starting USB-Serial mode"
 	usb_mode_func peripheral
 	rm_gadget_func
@@ -220,11 +226,10 @@ if test "${USB_MODE}" == "serial"; then
 	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
 	usb_mode_func
-fi
 
 ### Networking ###
-if test "${USB_MODE}" == "net"; then
-	st_info_func "Starting USB-Network mode"
+elif test "${USB_MODE}" == "net"; then
+	echo "Starting USB-Network mode"
 	rm_gadget_func
 	modprobe usb_f_rndis
 	sleep 1
@@ -234,10 +239,9 @@ if test "${USB_MODE}" == "net"; then
 	ifconfig usb0 up 192.168.137.1
 	sleep 10
 	/etc/init.d/S80dhcp-server restart
-fi
 
 ### Host ##
-if test "${USB_MODE}" == "host"; then
+elif test "${USB_MODE}" == "host"; then
 	echo "Starting USB in HOST state mode"
 	usb_mode_func host
 	sleep 2
@@ -255,6 +259,13 @@ if test "${USB_MODE}" == "host"; then
 	modprobe hid-generic
 	modprobe hid
 	usb_mode_func
+
+### UNKNOWN ##
+else
+	echo "ERROR: Unknown USB_MODE=${USB_MODE} in 1st arg"
+	exit 1
 fi
 
-echo "Exiting USB mode configuration..."
+# Export envar & exit successfully app
+export USB_MODE
+echo "Finished USB ${USB_MODE} mode configuration..."

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -2,10 +2,10 @@
 
 # ARGS
 USB_MODE="${1}" # mtp(default); hid; serial; net; host
-test "${2}" == "main" \
- && USB_MAIN=true \
- || USB_MAIN=false
-echo "USB main run status: ${USB_MAIN}"
+test -f /tmp/usbmode.active \
+ && USB_ACTIVE=true \
+ || USB_ACTIVE=false
+echo "USB active status: ${USB_ACTIVE}"
 
 # Global variables
 SYSDIR=/sys/kernel/config/usb_gadget
@@ -63,7 +63,7 @@ rm_gadget_func(){
 	echo "exiting Remove gadget process..."
 	return
 
-	# TODO: see why we need to disable below cmds for switching USB mode from HOST (main run) to other
+	# TODO: see why we need to disable below cmds for switching USB mode from HOST (firstrun) to other
 	echo "Removing functions"
 	for func in $DEVDIR/functions/*.*; do
 		[ -d $func ] && rmdir $func
@@ -176,11 +176,17 @@ usb_configs_func(){
 	fi
 }
 
+# load necessary kernel modules
+if ! ${USB_ACTIVE}; then
+	modprobe sunxi
+	modprobe usb_f_fs
+fi
+
 ### MTP/MTD (default) ###
 if test "${USB_MODE}" == "mtp"; then
 	echo "Starting USB-MTP mode"
-	if ! ${USB_MAIN}; then
-		rm_gadget_func # omit removing gadgets in main run
+	if ${USB_ACTIVE}; then
+		rm_gadget_func # omit removing gadgets in firstrun run
 		usb_mode_func peripheral
 	fi
 
@@ -190,7 +196,7 @@ if test "${USB_MODE}" == "mtp"; then
 		rm_gadget_func
 		usb_configs_func
 	fi
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		if ! (pgrep "umtprd" || pgrep "umtprd-debug"); then
 			echo "Launching uMTP-Responder app for usb-mtp mode"
 			if (grep -q DEBUG_UMTPR\=\1 "${HOME}/options.cfg"); then
@@ -210,7 +216,7 @@ if test "${USB_MODE}" == "mtp"; then
 ### HID ###
 elif test "${USB_MODE}" == "hid"; then
 	echo "Starting USB-HID mode"
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		rm_gadget_func
 		usb_mode_func peripheral
 	fi
@@ -220,7 +226,7 @@ elif test "${USB_MODE}" == "hid"; then
 	mount none /sys/kernel/config -t configfs
 	gadget-hid
 	usb_mode_func
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		st_exec_func "\
 			echo -e \"\e[32m\n\n\n\n\n\n               Starting USB-HID mode\e[0m\n\n\n\"; \
 			sleep 1; \
@@ -238,7 +244,7 @@ elif test "${USB_MODE}" == "hid"; then
 ### Serial Console ###
 elif test "${USB_MODE}" == "serial"; then
 	echo "Starting USB-Serial mode"
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		rm_gadget_func
 		usb_mode_func peripheral
 	fi
@@ -249,7 +255,7 @@ elif test "${USB_MODE}" == "serial"; then
 ### Networking ###
 elif test "${USB_MODE}" == "net"; then
 	echo "Starting USB-Network mode"
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		rm_gadget_func
 		usb_mode_func peripheral
 	fi
@@ -264,7 +270,7 @@ elif test "${USB_MODE}" == "net"; then
 ### Host ##
 elif test "${USB_MODE}" == "host"; then
 	echo "Starting USB in HOST state mode"
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		usb_mode_func host
 	else
 		usb_configs_func # run similary to serial
@@ -283,7 +289,7 @@ elif test "${USB_MODE}" == "host"; then
 	modprobe usbhid
 	modprobe hid-generic
 	modprobe hid
-	if ! ${USB_MAIN}; then
+	if ${USB_ACTIVE}; then
 		usb_mode_func
 	else
 		sleep 1
@@ -299,4 +305,5 @@ fi
 
 # Export envar & exit successfully app
 echo "USB_MODE=${USB_MODE}" > ${HOME}/.usbmode
+touch /tmp/usbmode.active
 echo "Finished USB ${USB_MODE} mode configuration..."

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -15,6 +15,11 @@ MAC_DEV="12:34:56:78:9a:bc"
 USB_MODE_PATH="/sys/devices/platform/soc/1c13000.usb/musb-hdrc.1.auto/mode"
 UDC_GADGET=${DEVDIR}/UDC
 
+# Externall variables
+test -z "${LOGS_TEMP}" && LOGS_TEMP=/dev/null
+test -z "${UMTPR_LOGS}" && UMTPR_LOGS=/dev/null
+#test "x${DEBUG_UMTPR}" == "xyes" && echo "Debugging umtprd mode is active"
+
 st_error_func(){
 	st -k -e "/bin/sh" "-c" "echo -e \"\e[31m${1}\e[0m\"; sleep 2"
 }
@@ -206,17 +211,16 @@ if test "${USB_MODE}" == "mtp"; then
 		rm_gadget_func
 		usb_configs_func
 	fi
-	if ${USB_ACTIVE}; then
-		if ! (pgrep "umtprd" || pgrep "umtprd-debug"); then
-			echo "Launching uMTP-Responder app for usb-mtp mode"
-			if (grep -q DEBUG_UMTPR\=\1 "${HOME}/options.cfg"); then
-				umtprd-debug &
-			else
-				umtprd &
-			fi
+	if ! (pgrep "umtprd" || pgrep "umtprd-debug"); then
+		echo "Launching uMTP-Responder app for usb-mtp mode"
+		if test "x${DEBUG_UMTPR}" == "xyes" ; then
+			echo "Starting umtprd in debug mode"
+			umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
 		else
-			echo "uMTP-Responder in already running in bg for working MTP"
+			umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's bg process the stdout/err is constantly active, may brake cmds in upper shell (like mounting) so logging here to /dev/null
 		fi
+	else
+		echo "uMTP-Responder in already running in bg for working MTP"
 	fi
 	udc_gadget_func
 	usb_mode_func

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -267,5 +267,5 @@ else
 fi
 
 # Export envar & exit successfully app
-export USB_MODE
+echo "USB_MODE=${USB_MODE}" > ${HOME}/.usbmode
 echo "Finished USB ${USB_MODE} mode configuration..."

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -13,6 +13,7 @@ DEVDIR=$SYSDIR/g2
 MAC_HOST="12:34:56:78:9a:bd"
 MAC_DEV="12:34:56:78:9a:bc"
 USB_MODE_PATH="/sys/devices/platform/soc/1c13000.usb/musb-hdrc.1.auto/mode"
+USB_MODE_CFG=${HOME}/.usbmode
 UDC_GADGET=${DEVDIR}/UDC
 
 # Externall variables
@@ -39,7 +40,7 @@ rm_gadget_func(){
 		echo "Shutting existing umtprd-debug app"
 		killall umtprd-debug
 	fi
-	if (grep -q hid "${HOME}/.usbmode"); then
+	if (test -r "${USB_MODE_CFG}" && grep -q hid "${USB_MODE_CFG}"); then
 		echo "Removing gadget HID"
 		gadget-vid-pid-remove 0x1d6b:0x0104 # rm gadget-hid (g_multi) - idProduct serial,net
 	fi
@@ -88,7 +89,7 @@ udc_gadget_func(){
 	echo "Linking UDC in ${UDC_GADGET} to existing musb gadget"
 	while [ -z "$(cat ${UDC_GADGET})" ]
 	do
-		sleep 1
+		sleep 0.1
 		ls /sys/class/udc/ > ${UDC_GADGET}
 	done
 }
@@ -114,7 +115,7 @@ usb_mode_func(){
 	 || echo "Suggesting USB mode in ../musb-hdrc.1.auto/mode"
 	_usb_mode_="$(cat ${USB_MODE_PATH})"
 	echo "Current USB mode=${_usb_mode_}"
-	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || grep -q host "${HOME}/.usbmode" && ! test -z "${1}"); then
+	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || (test -r "${USB_MODE_CFG}" && grep -q host "${USB_MODE_CFG}") && ! test -z "${1}"); then
 		rm_host_modules_func
 	fi
 	test -z "${1}" \
@@ -207,7 +208,7 @@ if test "${USB_MODE}" == "mtp"; then
 
 	usb_configs_func
 	# TODO: see why we need to perform MTP setup twice if switching from host mode
-	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || grep -q host "${HOME}/.usbmode"); then
+	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || (test -r "${USB_MODE_CFG}" && grep -q host "${USB_MODE_CFG}")); then
 		rm_gadget_func
 		usb_configs_func
 	fi
@@ -222,6 +223,7 @@ if test "${USB_MODE}" == "mtp"; then
 	else
 		echo "uMTP-Responder in already running in bg for working MTP"
 	fi
+	sleep 1
 	udc_gadget_func
 	usb_mode_func
 
@@ -249,7 +251,7 @@ elif test "${USB_MODE}" == "hid"; then
 		echo -e "\e[32m\n\n     Press RESET after 5s to exit...\e[0m" &>$(tty)
 		python /usr/bin/usb-hid.py
 	fi
-	modprobe -r usb_f_hid
+	modprobe -r usb_f_hid # does't unload, cuz it's binded to libcomposite with other usb_f* modules
 	modprobe -r evdev
 	modprobe -r uinput
 
@@ -304,6 +306,7 @@ elif test "${USB_MODE}" == "host"; then
 	if ${USB_ACTIVE}; then
 		usb_mode_func
 	else
+		sleep 1
 		udc_gadget_func
 		usb_mode_func host
 	fi
@@ -315,7 +318,7 @@ else
 fi
 
 # Export envar & exit successfully app
-echo "USB_MODE=${USB_MODE}" > ${HOME}/.usbmode
+echo "USB_MODE=${USB_MODE}" > ${USB_MODE_CFG}
 touch /tmp/usbmode.active
 if ! test -z "${UDC_GADGET}"; then
 	echo "UDC activated via ${UDC_GADGET}"

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -172,11 +172,7 @@ if test "${USB_MODE}" == "mtp"; then
 	echo "Starting USB-MTP mode"
 	if ! ${USB_MAIN}; then
 		usb_mode_func peripheral
-	fi
-	modprobe usb_f_fs
-	if ! ${USB_MAIN}; then
-	# omit removing gadgets in main run
-		rm_gadget_func
+		rm_gadget_func # omit removing gadgets in main run
 	fi
 
 	usb_configs_func
@@ -192,11 +188,9 @@ if test "${USB_MODE}" == "mtp"; then
 			echo "uMTP-Responder in already running in bg for working MTP"
 		fi
 	fi
-	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
 
 	usb_mode_func
-	sleep 1
 
 ### HID ###
 elif test "${USB_MODE}" == "hid"; then
@@ -227,7 +221,6 @@ elif test "${USB_MODE}" == "serial"; then
 		rm_gadget_func
 	fi
 	usb_configs_func
-	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
 	usb_mode_func
 
@@ -240,7 +233,6 @@ elif test "${USB_MODE}" == "net"; then
 	modprobe usb_f_rndis
 	sleep 1
 	usb_configs_func
-	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
 	ifconfig usb0 up 192.168.137.1
 	sleep 10

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -30,7 +30,9 @@ rm_gadget_func(){
 	elif pgrep "umtprd-debug"; then
 		killall umtprd-debug
 	fi
-	gadget-vid-pid-remove 0x1d6b:0x0104 # simply rm gadget-hid (g_hid/g_multi?) as it isn't part of FunctionFS 
+	if (grep -q hid "${HOME}/.usbmode"); then
+		gadget-vid-pid-remove 0x1d6b:0x0104 # rm gadget-hid (g_multi) - idProduct serial,net
+	fi
 
 	if ! test -d $DEVDIR; then
 		echo "ERROR: couldn't find ${DEVDIR}"

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -215,7 +215,7 @@ if test "${USB_MODE}" == "mtp"; then
 		echo "Launching uMTP-Responder app for usb-mtp mode"
 		if test "x${DEBUG_UMTPR}" == "xyes" ; then
 			echo "Starting umtprd in debug mode"
-			umtprd-debug >> "${LOGS_TEMP}" 2>&1 &
+			umtprd-debug >> "${UMTPR_LOGS}" 2>&1 &
 		else
 			umtprd >> ${UMTPR_LOGS} 2>&1 & # since it's bg process the stdout/err is constantly active, may brake cmds in upper shell (like mounting) so logging here to /dev/null
 		fi

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -111,7 +111,7 @@ usb_configs_func(){
 	mkdir -p configs/c.1
 	if test "${USB_MODE}" == "mtp"; then
 		mkdir -p functions/ffs.mtp # mtp
-	elif test "${USB_MODE}" == "serial"; then
+	elif test "${USB_MODE}" == "serial" || test "${USB_MODE}" == "host"; then
 		mkdir -p functions/acm.usb0 # serial
 	# else net
 	fi
@@ -141,7 +141,7 @@ usb_configs_func(){
 	fi
 	echo "Miyoo Handheld" > strings/0x409/manufacturer
 	echo "MiyooCFW 2.0" > strings/0x409/product
-	if test "${USB_MODE}" == "serial"; then
+	if test "${USB_MODE}" == "serial" || test "${USB_MODE}" == "host"; then
 		echo "deadbeef12345678" > strings/0x409/serialnumber
 	fi
 
@@ -152,7 +152,7 @@ usb_configs_func(){
 		ln -s functions/ffs.mtp configs/c.1
 		mkdir -p /dev/ffs-mtp
 		mount -t functionfs mtp /dev/ffs-mtp
-	elif test "${USB_MODE}" == "serial"; then
+	elif test "${USB_MODE}" == "serial" || test "${USB_MODE}" == "host"; then
 		# serial
 		ln -s functions/acm.usb0 configs/c.1
 	elif test "${USB_MODE}" == "net"; then
@@ -188,6 +188,7 @@ if test "${USB_MODE}" == "mtp"; then
 			echo "uMTP-Responder in already running in bg for working MTP"
 		fi
 	fi
+	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
 
 	usb_mode_func
@@ -205,10 +206,17 @@ elif test "${USB_MODE}" == "hid"; then
 	mount none /sys/kernel/config -t configfs
 	gadget-hid
 	usb_mode_func
-	st_exec_func "\
-		echo -e \"\e[32m\n\n\n\n\n\n               Starting USB-HID mode\e[0m\n\n\n\"; \
-		sleep 1; \
-		python /usr/bin/usb-hid.py"
+	if ! ${USB_MAIN}; then
+		st_exec_func "\
+			echo -e \"\e[32m\n\n\n\n\n\n               Starting USB-HID mode\e[0m\n\n\n\"; \
+			sleep 1; \
+			python /usr/bin/usb-hid.py"
+	else
+		echo -e "\e[32m\n\n\n\n\n\n        Starting USB-HID mode\e[0m\n\n\n" &>$(tty)
+		sleep 1
+		echo -e "\e[32m\n\n     Press RESET after 5s to exit...\e[0m" &>$(tty)
+		python /usr/bin/usb-hid.py
+	fi
 	modprobe -r usb_f_hid
 	modprobe -r evdev
 	modprobe -r uinput
@@ -241,7 +249,11 @@ elif test "${USB_MODE}" == "net"; then
 ### Host ##
 elif test "${USB_MODE}" == "host"; then
 	echo "Starting USB in HOST state mode"
-	usb_mode_func host
+	if ! ${USB_MAIN}; then
+		usb_mode_func host
+	else
+		usb_configs_func # run similary to serial
+	fi
 	sleep 2
 
 	modprobe evdev
@@ -256,7 +268,13 @@ elif test "${USB_MODE}" == "host"; then
 	modprobe usbhid
 	modprobe hid-generic
 	modprobe hid
-	usb_mode_func
+	if ! ${USB_MAIN}; then
+		usb_mode_func
+	else
+		sleep 1
+		ls /sys/class/udc/ > ${DEVDIR}/UDC
+		usb_mode_func host
+	fi
 
 ### UNKNOWN ##
 else

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -1,8 +1,11 @@
 #!/bin/busybox sh
 
 # ARGS
-USB_MODE="${1}" # mtp(default no-arg); hid; serial; net; host
-MTP_APP="${2}" # umtprd
+USB_MODE="${1}" # mtp(default); hid; serial; net; host
+test "${2}" == "main" \
+ && USB_MAIN=true \
+ || USB_MAIN=false
+echo "USB main run status: ${USB_MAIN}"
 
 # Global variables
 SYSDIR=/sys/kernel/config/usb_gadget
@@ -106,7 +109,7 @@ usb_configs_func(){
 		exit 1
 	fi
 	mkdir -p configs/c.1
-	if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
+	if test "${USB_MODE}" == "mtp"; then
 		mkdir -p functions/ffs.mtp # mtp
 	elif test "${USB_MODE}" == "serial"; then
 		mkdir -p functions/acm.usb0 # serial
@@ -117,7 +120,7 @@ usb_configs_func(){
 	if test "${USB_MODE}" == "net"; then
 		mkdir -p functions/rndis.usb0
 	fi
-	if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
+	if test "${USB_MODE}" == "mtp"; then
 		echo 0x0100 > idProduct # mtp gadget (ptp's extension)
 	else
 		echo 0x0104 > idProduct # serial,net (g_multi?), CDC ACM
@@ -144,7 +147,7 @@ usb_configs_func(){
 
 	echo "Conf 1" > configs/c.1/strings/0x409/configuration
 	echo 120 > configs/c.1/MaxPower
-	if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
+	if test "${USB_MODE}" == "mtp"; then
 		# mtp
 		ln -s functions/ffs.mtp configs/c.1
 		mkdir -p /dev/ffs-mtp
@@ -165,32 +168,29 @@ usb_configs_func(){
 }
 
 ### MTP/MTD (default) ###
-if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
+if test "${USB_MODE}" == "mtp"; then
 	echo "Starting USB-MTP mode"
-	test -z $USB_MODE \
-	 || usb_mode_func peripheral
+	if ! ${USB_MAIN}; then
+		usb_mode_func peripheral
+	fi
 	modprobe usb_f_fs
-	if ! test -z $USB_MODE; then
-	# omit removing gadgets in default non-arg run
+	if ! ${USB_MAIN}; then
+	# omit removing gadgets in main run
 		rm_gadget_func
-	else
-	# define envar if empty
-		USB_MODE="mtp"
 	fi
 
 	usb_configs_func
-	if test "${MTP_APP}" == "umtprd"; then
-		echo "Launching uMTP-Responder app"
-		if (grep -q DEBUG_UMTPR\=\1 "${HOME}/options.cfg"); then
-			umtprd-debug &
+	if ! ${USB_MAIN}; then
+		if ! (pgrep "umtprd" || pgrep "umtprd-debug"); then
+			echo "Launching uMTP-Responder app for usb-mtp mode"
+			if (grep -q DEBUG_UMTPR\=\1 "${HOME}/options.cfg"); then
+				umtprd-debug &
+			else
+				umtprd &
+			fi
 		else
-			umtprd &
+			echo "uMTP-Responder in already running in bg for working MTP"
 		fi
-	elif test -z ${MTP_APP}; then
-		echo "Please run uMTP-Responder in bg for working MTP"
-	else
-		echo "ERROR: Unknown MTP_APP=${MTP_APP} in 2nd arg"
-		exit 1
 	fi
 	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
@@ -201,8 +201,10 @@ if test "${USB_MODE}" == "mtp" || test -z $USB_MODE; then
 ### HID ###
 elif test "${USB_MODE}" == "hid"; then
 	echo "Starting USB-HID mode"
-	usb_mode_func peripheral
-	rm_gadget_func
+	if ! ${USB_MAIN}; then
+		usb_mode_func peripheral
+		rm_gadget_func
+	fi
 	modprobe usb_f_hid
 	modprobe evdev
 	modprobe uinput
@@ -220,8 +222,10 @@ elif test "${USB_MODE}" == "hid"; then
 ### Serial Console ###
 elif test "${USB_MODE}" == "serial"; then
 	echo "Starting USB-Serial mode"
-	usb_mode_func peripheral
-	rm_gadget_func
+	if ! ${USB_MAIN}; then
+		usb_mode_func peripheral
+		rm_gadget_func
+	fi
 	usb_configs_func
 	sleep 1
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
@@ -230,7 +234,9 @@ elif test "${USB_MODE}" == "serial"; then
 ### Networking ###
 elif test "${USB_MODE}" == "net"; then
 	echo "Starting USB-Network mode"
-	rm_gadget_func
+	if ! ${USB_MAIN}; then
+		rm_gadget_func
+	fi
 	modprobe usb_f_rndis
 	sleep 1
 	usb_configs_func

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -13,6 +13,7 @@ DEVDIR=$SYSDIR/g2
 MAC_HOST="12:34:56:78:9a:bd"
 MAC_DEV="12:34:56:78:9a:bc"
 USB_MODE_PATH="/sys/devices/platform/soc/1c13000.usb/musb-hdrc.1.auto/mode"
+UDC_GADGET=${DEVDIR}/UDC
 
 st_error_func(){
 	st -k -e "/bin/sh" "-c" "echo -e \"\e[31m${1}\e[0m\"; sleep 2"
@@ -76,6 +77,15 @@ rm_gadget_func(){
 
 	echo "Removing gadget"
 	rmdir $DEVDIR
+}
+
+udc_gadget_func(){
+	echo "Linking UDC in ${UDC_GADGET} to existing musb gadget"
+	while [ -z "$(cat ${UDC_GADGET})" ]
+	do
+		sleep 1
+		ls /sys/class/udc/ > ${UDC_GADGET}
+	done
 }
 
 rm_host_modules_func(){
@@ -208,9 +218,7 @@ if test "${USB_MODE}" == "mtp"; then
 			echo "uMTP-Responder in already running in bg for working MTP"
 		fi
 	fi
-	sleep 1
-	ls /sys/class/udc/ > ${DEVDIR}/UDC
-
+	udc_gadget_func
 	usb_mode_func
 
 ### HID ###
@@ -249,7 +257,7 @@ elif test "${USB_MODE}" == "serial"; then
 		usb_mode_func peripheral
 	fi
 	usb_configs_func
-	ls /sys/class/udc/ > ${DEVDIR}/UDC
+	udc_gadget_func
 	usb_mode_func
 
 ### Networking ###
@@ -262,7 +270,7 @@ elif test "${USB_MODE}" == "net"; then
 	modprobe usb_f_rndis
 	sleep 1
 	usb_configs_func
-	ls /sys/class/udc/ > ${DEVDIR}/UDC
+	udc_gadget_func
 	ifconfig usb0 up 192.168.137.1
 	sleep 10
 	/etc/init.d/S80dhcp-server restart
@@ -292,8 +300,7 @@ elif test "${USB_MODE}" == "host"; then
 	if ${USB_ACTIVE}; then
 		usb_mode_func
 	else
-		sleep 1
-		ls /sys/class/udc/ > ${DEVDIR}/UDC
+		udc_gadget_func
 		usb_mode_func host
 	fi
 
@@ -306,4 +313,10 @@ fi
 # Export envar & exit successfully app
 echo "USB_MODE=${USB_MODE}" > ${HOME}/.usbmode
 touch /tmp/usbmode.active
+if ! test -z "${UDC_GADGET}"; then
+	echo "UDC activated via ${UDC_GADGET}"
+else
+	echo "ERROR: Failed to bind usb gadget to UDC"
+	exit 1
+fi
 echo "Finished USB ${USB_MODE} mode configuration..."

--- a/board/miyoo/rootfs/usr/bin/usb-mode
+++ b/board/miyoo/rootfs/usr/bin/usb-mode
@@ -12,6 +12,7 @@ SYSDIR=/sys/kernel/config/usb_gadget
 DEVDIR=$SYSDIR/g2
 MAC_HOST="12:34:56:78:9a:bd"
 MAC_DEV="12:34:56:78:9a:bc"
+USB_MODE_PATH="/sys/devices/platform/soc/1c13000.usb/musb-hdrc.1.auto/mode"
 
 st_error_func(){
 	st -k -e "/bin/sh" "-c" "echo -e \"\e[31m${1}\e[0m\"; sleep 2"
@@ -26,11 +27,14 @@ st_exec_func(){
 rm_gadget_func(){
 	echo "Removing old gadgets"
 	if pgrep "umtprd"; then
+		echo "Shutting existing umtprd app"
 		killall umtprd
 	elif pgrep "umtprd-debug"; then
+		echo "Shutting existing umtprd-debug app"
 		killall umtprd-debug
 	fi
 	if (grep -q hid "${HOME}/.usbmode"); then
+		echo "Removing gadget HID"
 		gadget-vid-pid-remove 0x1d6b:0x0104 # rm gadget-hid (g_multi) - idProduct serial,net
 	fi
 
@@ -56,6 +60,10 @@ rm_gadget_func(){
 		[ -d $conf ] && rmdir $conf
 	done
 
+	echo "exiting Remove gadget process..."
+	return
+
+	# TODO: see why we need to disable below cmds for switching USB mode from HOST (main run) to other
 	echo "Removing functions"
 	for func in $DEVDIR/functions/*.*; do
 		[ -d $func ] && rmdir $func
@@ -89,16 +97,15 @@ rm_host_modules_func(){
 usb_mode_func(){
 	test -z "${1}" \
 	 || echo "Suggesting USB mode in ../musb-hdrc.1.auto/mode"
-	_usb_mode_path_="/sys/devices/platform/soc/1c13000.usb/musb-hdrc.1.auto/mode"
-	_usb_mode_="$(cat ${_usb_mode_path_})"
+	_usb_mode_="$(cat ${USB_MODE_PATH})"
 	echo "Current USB mode=${_usb_mode_}"
-	if (grep -q host "${_usb_mode_path_}" && ! test -z "${1}"); then
+	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || grep -q host "${HOME}/.usbmode" && ! test -z "${1}"); then
 		rm_host_modules_func
 	fi
 	test -z "${1}" \
-	 || echo "${1}" > ${_usb_mode_path_} # DOES THIS EVEN WORK?
+	 || echo "${1}" > ${USB_MODE_PATH} # DOES THIS EVEN WORK?
 	sleep 1
-	# _usb_mode_="$(cat ${_usb_mode_path_})"
+	# _usb_mode_="$(cat ${USB_MODE_PATH})"
 	# echo "NEW usb_mode=${_usb_mode_}"
 }
 
@@ -173,11 +180,16 @@ usb_configs_func(){
 if test "${USB_MODE}" == "mtp"; then
 	echo "Starting USB-MTP mode"
 	if ! ${USB_MAIN}; then
-		usb_mode_func peripheral
 		rm_gadget_func # omit removing gadgets in main run
+		usb_mode_func peripheral
 	fi
 
 	usb_configs_func
+	# TODO: see why we need to perform MTP setup twice if switching from host mode
+	if (grep -Eq 'host|wait_vrise|wait_bcon' "${USB_MODE_PATH}" || grep -q host "${HOME}/.usbmode"); then
+		rm_gadget_func
+		usb_configs_func
+	fi
 	if ! ${USB_MAIN}; then
 		if ! (pgrep "umtprd" || pgrep "umtprd-debug"); then
 			echo "Launching uMTP-Responder app for usb-mtp mode"
@@ -199,8 +211,8 @@ if test "${USB_MODE}" == "mtp"; then
 elif test "${USB_MODE}" == "hid"; then
 	echo "Starting USB-HID mode"
 	if ! ${USB_MAIN}; then
-		usb_mode_func peripheral
 		rm_gadget_func
+		usb_mode_func peripheral
 	fi
 	modprobe usb_f_hid
 	modprobe evdev
@@ -227,8 +239,8 @@ elif test "${USB_MODE}" == "hid"; then
 elif test "${USB_MODE}" == "serial"; then
 	echo "Starting USB-Serial mode"
 	if ! ${USB_MAIN}; then
-		usb_mode_func peripheral
 		rm_gadget_func
+		usb_mode_func peripheral
 	fi
 	usb_configs_func
 	ls /sys/class/udc/ > ${DEVDIR}/UDC
@@ -239,6 +251,7 @@ elif test "${USB_MODE}" == "net"; then
 	echo "Starting USB-Network mode"
 	if ! ${USB_MAIN}; then
 		rm_gadget_func
+		usb_mode_func peripheral
 	fi
 	modprobe usb_f_rndis
 	sleep 1


### PR DESCRIPTION
- add USB_OTG to options.cfg & main (disable/enable in main)
- create `/mnt/.usbmode` at startup and modify in re-run to detect current `$USB_MODE='mtp|hid|serial|net|host`
- the USB mode stays unchanged at last picked variant even after OS reset (read from `.usbmode` file in /etc/main)
- rm old USB AppLinks in gmenu2x, so ditch old method in favor of UDC detect in frontend

