### PR TITLE
BOARD: retroarch-setup: fix musl `sed` cli expression

### DIFF
--- a/board/miyoo/rootfs/usr/bin/retroarch-setup
+++ b/board/miyoo/rootfs/usr/bin/retroarch-setup
@@ -65,10 +65,10 @@ else
         if grep -q '^params=' "$file"; then
           #Warning: escape "-" sign for grep cmd in BB otherwise it will fail
           grep -q '\--appendconfig=' "$file" && \
-            #Warning: in POSIX using "|" is safer delimer than "/" since paths can contain these also (likewise here)
+            #Warning: in POSIX using ":" is safer delimer than "/" or "|" since paths or cmds can contain these also (likewise here)
             ##Below cmd replaces first occurence of appendconfig, append "g" for global
-            sed -i "s|--appendconfig=[^[:space:]]*|--appendconfig=\"${ra_append_cfg}\"|" "$file"\
-          ||sed -i "/^params=/ s|\$| --appendconfig=\"${ra_append_cfg}\"|" "$file"
+            sed -i "s:--appendconfig=[^[:space:]]*:--appendconfig=\"${ra_append_cfg}\":" "$file"\
+          ||sed -i "/^params=/ s:$: --appendconfig=\"${ra_append_cfg}\":" "$file"
         else
           echo "params=--appendconfig=\"${ra_append_cfg}\"" >> "$file"
         fi

--- a/board/miyoo/rootfs/usr/bin/retroarch-setup
+++ b/board/miyoo/rootfs/usr/bin/retroarch-setup
@@ -67,10 +67,10 @@ else
           grep -q '\--appendconfig=' "$file" && \
             #Warning: in POSIX using "|" is safer delimer than "/" since paths can contain these also (likewise here)
             ##Below cmd replaces first occurence of appendconfig, append "g" for global
-            sed -i "s|--appendconfig=[^[:space:]]*|--appendconfig=${ra_append_cfg}|" "$file"\
-          ||sed -i "/^params=/ s|\$| --appendconfig=${ra_append_cfg}|" "$file"
+            sed -i "s|--appendconfig=[^[:space:]]*|--appendconfig=\"${ra_append_cfg}\"|" "$file"\
+          ||sed -i "/^params=/ s|\$| --appendconfig=\"${ra_append_cfg}\"|" "$file"
         else
-          echo "params=--appendconfig=${ra_append_cfg}" >> "$file"
+          echo "params=--appendconfig=\"${ra_append_cfg}\"" >> "$file"
         fi
       done
     else


### PR DESCRIPTION
- brace with quotes --appendconfig args
- use ":" delimeter instead for sed

otherwise sed fails in musl libc