### PR TITLE
PKG: retroarch: enable VRR_RUNLOOP & block GameFocus

### DIFF
--- a/package/miyoo/retroarch/libretro-retroarch/0016-block-Game-Focus-hotkey-if-disabled-blocked.patch
+++ b/package/miyoo/retroarch/libretro-retroarch/0016-block-Game-Focus-hotkey-if-disabled-blocked.patch
@@ -1,0 +1,29 @@
+From 22cdf4b5ae258a7c88adc8a314dfcbcaaa89ae6a Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Wed, 1 Apr 2026 23:16:26 +0200
+Subject: [PATCH] block "Game Focus" hotkey if disabled & blocked
+
+to work with "Hotkey Enable" combination only for enabling (not disabling)
+---
+ input/input_driver.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/input/input_driver.c b/input/input_driver.c
+index 0b372b336f..d671c26e4d 100644
+--- a/input/input_driver.c
++++ b/input/input_driver.c
+@@ -6234,7 +6234,11 @@ static void input_keys_pressed(
+ 
+    if (!is_menu && binds[port][RARCH_GAME_FOCUS_TOGGLE].valid)
+    {
++      input_game_focus_state_t *game_focus_st = &input_driver_st.game_focus_state;
++
+       /* Never block Game Focus toggle hotkey */
++      /* Ensure that game focus mode is disabled */
++      if (game_focus_st->enabled)
+       block_hotkey[RARCH_GAME_FOCUS_TOGGLE] = false;
+    }
+ 
+-- 
+2.45.2.windows.1
+

--- a/package/miyoo/retroarch/libretro-retroarch/0017-config.def.h-enable-VRR_RUNLOOP.patch
+++ b/package/miyoo/retroarch/libretro-retroarch/0017-config.def.h-enable-VRR_RUNLOOP.patch
@@ -1,0 +1,28 @@
+From 8f7b7126d23c14958e9ba2848b9bf4df92d214ca Mon Sep 17 00:00:00 2001
+From: Apaczer <94932128+Apaczer@users.noreply.github.com>
+Date: Mon, 20 Apr 2026 22:55:53 +0200
+Subject: [PATCH] config.def.h: enable VRR_RUNLOOP
+
+"Sync to Exact Content Frame Rate (G-Sync, FreeSync)" -> ON
+
+fixes horrendous uneven frame-pacing
+---
+ config.def.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.def.h b/config.def.h
+index abbe0d83a2..14d9ad7415 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -1452,7 +1452,7 @@
+ #define DEFAULT_FASTFORWARD_FRAMESKIP true
+ 
+ /* Enable runloop for variable refresh rate screens. Force x1 speed while handling fast forward too. */
+-#define DEFAULT_VRR_RUNLOOP_ENABLE false
++#define DEFAULT_VRR_RUNLOOP_ENABLE true
+ 
+ /* Run core logic one or more frames ahead then load the state back to reduce perceived input lag. */
+ #define DEFAULT_RUN_AHEAD_FRAMES 1
+-- 
+2.45.2.windows.1
+


### PR DESCRIPTION
hotfixes patches for retroarch
- block "Game Focus" hotkey if disabled & blocked to work with "Hotkey Enable" combination only for enabling (not disabling)
- enable VRR_RUNLOOP aka "Sync to Exact Content Frame Rate (G-Sync, FreeSync)" which fixes horrendous uneven framerate...

The Vsync still works badly with fastforward (even via hotkeys), so keeping that OFF for the time being.